### PR TITLE
Remove unnecessary requirements

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,6 +3,3 @@
 
 # gevent for async workers
 gevent==0.13.8
-
-# For Sentry
-raven==5.17.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,9 +4,5 @@
 # gevent for async workers
 gevent==0.13.8
 
-# Memcache
-pylibmc==1.2.2
-django-pylibmc-sasl==0.2.4
-
 # For Sentry
 raven==5.17.0


### PR DESCRIPTION
pylibmc 1.2.2 is ancient and is incompatible with recent versions of libmemcached, so this requirement needs to be updated.  However, by default Tendenci is configured to use python-memcached instead of pylibmc, so this requirement is not actually needed at all and can simply be removed.

In addition, the tendenci module already requires raven, so that requirement is redundant.

Fixes #4