### PR TITLE
Fix django-debug-toolbar config and add comments

### DIFF
--- a/conf/local_settings.py
+++ b/conf/local_settings.py
@@ -143,7 +143,19 @@ EXPLORER_PERMISSION_CHANGE =  lambda u: u.is_superuser
 
 # debug mode
 DEBUG = False
-DEBUG_TOOLBAR = False
+
+# Django Debug Toolbar for profiling (measuring CPU/SQL/cache/etc timing)
+# Set DEBUG_TOOLBAR_INSTALLED to deploy the relevant static files (when
+# `python manage.py deploy` is run) and add the necessary middleware.
+# Set DEBUG_TOOLBAR_ENABLED to actually enable profiling and the toolbar.
+# DEBUG_TOOLBAR_INSTALLED should not impact performance, but
+# DEBUG_TOOLBAR_ENABLED will slow down Django.
+DEBUG_TOOLBAR_INSTALLED = True
+DEBUG_TOOLBAR_ENABLED = False
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': lambda req: DEBUG_TOOLBAR_ENABLED,
+    'SHOW_COLLAPSED': False,
+}
 
 TEMPLATES = get_setting('TEMPLATES')
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -111,15 +111,9 @@ except ImportError:
 # -------------------------------------- #
 # DEBUG OPTIONS
 # -------------------------------------- #
-if DEBUG_TOOLBAR:
+if DEBUG_TOOLBAR_INSTALLED:
     INSTALLED_APPS += ('debug_toolbar',)
     MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
-    
-    def show_toolbar():
-        return True
-
-    # You can specify INTERNAL_IPS, then remove this setting
-    SHOW_TOOLBAR_CALLBACK = show_toolbar()
 
 
 # THIS MUST BE AT THE END!


### PR DESCRIPTION
SHOW_TOOLBAR_CALLBACK was not configured properly, and there were no
comments explaining what this feature was or how to get it working.