### PR TITLE
Edit boomerang theme to use scheme-less URL for Google fonts.

### DIFF
--- a/themes/boomerang/media/css/global-style.css
+++ b/themes/boomerang/media/css/global-style.css
@@ -1,2 +1,11252 @@
-/* CSS crunched with Crunch - http://crunchapp.net/ */
-@import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic);@import "http://fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic";@import url(../assets/fancybox/jquery.fancybox.css?v=2.1.5);@import url(../assets/animate/animate.css);@import url(../assets/easy-pie-chart/easypiechart.css);@import url(../assets/timeline/timeline.css);body{font-family:"PT Sans",sans-serif !important;font-size:13px;line-height:22px;font-weight:300}body .lw{color:#666}body .ld{color:#888}.body-bg-1{background:url("../images/background/slash_it.png") repeat}.body-bg-2{background:url("../images/background/grey_wash_wall.png") repeat}.body-bg-3{background:url("../images/background/mooning.png") repeat}.body-bg-4{background:url("../images/background/squairy_light.png") repeat}.body-bg-5{background:url("../images/background/bg-img-1.jpg") no-repeat fixed}.body-bg-6{background:url("../images/background/bg-img-2.jpg") no-repeat fixed}.wp-theme-1 .btn{font-weight:normal;white-space:nowrap;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;border-radius:2px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.wp-theme-1 .btn i{margin-right:4px}.wp-theme-1 .btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:3px}.wp-theme-1 .btn-lg i{font-size:24px;position:relative;top:3px}.wp-theme-1 .btn-xs{padding:4px 10px}.wp-theme-1 .btn-one{background-color:none;border:2px solid #FFF;color:#FFF}.wp-theme-1 .btn-one:hover,.wp-theme-1 .btn-one:focus,.wp-theme-1 .btn-one:active,.wp-theme-1 .btn-one.active,.wp-theme-1 .open .dropdown-toggle.btn-one{color:#e91b23;background-color:#FFF;border-color:#FFF}.wp-theme-1 .btn-one:active,.wp-theme-1 .btn-one.active,.wp-theme-1 .open .dropdown-toggle.btn-one{background-image:none}.wp-theme-1 .btn-two{color:#ffffff;background-color:#e91b23;border:1px solid;border-color:#df1119}.wp-theme-1 .btn-two:hover,.wp-theme-1 .btn-two:focus,.wp-theme-1 .btn-two:active,.wp-theme-1 .btn-two.active,.wp-theme-1 .open .dropdown-toggle.btn-two{color:#ffffff;background-color:#d5070f;border-color:#d5070f}.wp-theme-1 .btn-two:active,.wp-theme-1 .btn-two.active,.wp-theme-1 .open .dropdown-toggle.btn-two{background-image:none}.wp-theme-1 .btn-three{color:#ffffff;background-color:#333;border:1px solid;border-color:#292929}.wp-theme-1 .btn-three:hover,.wp-theme-1 .btn-three:focus,.wp-theme-1 .btn-three:active,.wp-theme-1 .btn-three.active,.wp-theme-1 .open .dropdown-toggle.btn-three{color:#ffffff;background-color:#1f1f1f;border-color:#1f1f1f}.wp-theme-1 .btn-three:active,.wp-theme-1 .btn-three.active,.wp-theme-1 .open .dropdown-toggle.btn-three{background-image:none}.wp-theme-1 .btn-four{background-color:none;border:2px solid #e91b23;color:#e91b23}.wp-theme-1 .btn-four:hover,.wp-theme-1 .btn-four:focus,.wp-theme-1 .btn-four:active,.wp-theme-1 .btn-four.active,.wp-theme-1 .open .dropdown-toggle.btn-four{color:#FFF;background-color:#e91b23}.wp-theme-1 .btn-four:active,.wp-theme-1 .btn-four.active,.wp-theme-1 .open .dropdown-toggle.btn-four{background-image:none}.wp-theme-1 h1,.wp-theme-1 h2,.wp-theme-1 h3,.wp-theme-1 h4,.wp-theme-1 h5,.wp-theme-1 h6{font-family:"Roboto",sans-serif !important}.wp-theme-1 p{line-height:22px}.wp-theme-1 a{color:#616161;cursor:pointer}.wp-theme-1 a:hover{color:#e91b23;text-decoration:none;-o-transition:.3s;-ms-transition:.3s;-moz-transition:.3s;-webkit-transition:.3s;transition:.35s}.wp-theme-1 .bg-2{background:#e91b23;color:#FFF}.wp-theme-1 .lw .bg-5{background:#fcfcfc;border-top:1px solid #e0eded;border-bottom:1px solid #e0eded}.wp-theme-1 .ld .bg-5{background:#363636;border-top:1px solid #444;border-bottom:1px solid #444}.wp-theme-1 .lw .bg-3{background:#fff;color:#616161}.wp-theme-1 .ld .bg-3{background:#202020;color:#888}.wp-theme-1 .bg-4{background:#333;color:#FFF}.wp-theme-1 .dark{background:#333;color:#FFF}.wp-theme-1 .red{background:#e91b23;color:#FFF}.wp-theme-1 .orange{background:#f39c12;color:#FFF}.wp-theme-1 .green{background:#f39c12;color:#FFF}.wp-theme-1 .blue{background:#3498db;color:#FFF}.wp-theme-1 .light{background:#fff;color:#616161 !important}.wp-theme-1 .blockquote-1:hover{border-color:#e91b23}.wp-theme-1 .blockquote-1 p{font-size:13px}.wp-theme-1 .section-title{display:inline-block;border-bottom:1px solid #333;margin:0 0 15px 0;padding:0 0 5px 0;font-size:20px;font-weight:500;text-transform:capitalize;position:relative;overflow:hidden}.wp-theme-1 .lw .section-title{color:#333}.wp-theme-1 .ld .section-title{color:#fff}.wp-theme-1 .section-title.white{color:#fff;border-bottom:1px solid #fff}.wp-theme-1 .navbar-wp{margin:0;padding:0;border:0;border-radius:0;z-index:1000}.wp-theme-1 .lw .navbar-wp{background:#fff;border-bottom:1px solid #e0eded}.wp-theme-1 .ld .navbar-wp{background:#181818;border-bottom:1px solid #444}.wp-theme-1 .ld .sticky-wrapper .navbar-wp{background:rgba(24,24,24,0.85);border-bottom:1px solid #444}.wp-theme-1 .navbar-wp .navbar-nav>li>a{padding:28px 16px;margin-right:0;font-size:15px;font-weight:normal}.wp-theme-1 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-1 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-1 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-1 .lw .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#333}.wp-theme-1 .lw .navbar-wp .navbar-nav>li>a:hover,.wp-theme-1 .lw .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#e91b23}.wp-theme-1 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-1 .ld .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#fff}.wp-theme-1 .ld .navbar-wp .navbar-nav>li>a:hover,.wp-theme-1 .ld .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#e91b23}.wp-theme-1 .navbar-wp .navbar-nav>.active>a,.wp-theme-1 .navbar-wp .navbar-nav>.active>a:hover,.wp-theme-1 .navbar-wp .navbar-nav>.active>a:focus{color:#fff !important;background-color:#e91b23;border-radius:0}.wp-theme-1 .navbar-wp .navbar-nav>.disabled>a,.wp-theme-1 .navbar-wp .navbar-nav>.disabled>a:hover,.wp-theme-1 .navbar-wp .navbar-nav>.disabled>a:focus{color:#cccccc;background-color:transparent}.wp-theme-1 .navbar-wp .navbar-nav>.open>a,.wp-theme-1 .navbar-wp .navbar-nav>.open>a:hover,.wp-theme-1 .navbar-wp .navbar-nav>.open>a:focus{color:#FFF !important;background-color:#e91b23}.wp-theme-1 .navbar-wp .navbar-nav>.open>a .caret,.wp-theme-1 .navbar-wp .navbar-nav>.open>a:hover .caret,.wp-theme-1 .navbar-wp .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-1 .navbar-wp .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-1 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle,.wp-theme-1 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-1 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:focus{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none;color:#e91b23}.wp-theme-1 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle,.wp-theme-1 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:hover,.wp-theme-1 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:focus{color:#e91b23 !important;background-color:none}.wp-theme-1 .navbar-wp .navbar-toggle{border-color:#333;margin-top:20px}.wp-theme-1 .navbar-wp .navbar-toggle .icon-bar{background-color:#4c4c4c}.wp-theme-1 .navbar-wp .navbar-toggle .icon-custom{font-size:18px}.wp-theme-1 .navbar-wp .navbar-toggle:hover,.wp-theme-1 .navbar-wp .navbar-toggle:focus{background-color:#e91b23;border-color:#e91b23}.wp-theme-1 .navbar-wp .navbar-toggle:hover .icon-bar,.wp-theme-1 .navbar-wp .navbar-toggle:focus .icon-bar{background-color:#FFF}.wp-theme-1 .navbar-wp .navbar-toggle:hover .icon-custom,.wp-theme-1 .navbar-wp .navbar-toggle:focus .icon-custom{color:#FFF}.wp-theme-1 .navbar-wp .navbar-toggle-aside-menu{padding:8px 10px 2px 10px}.wp-theme-1 .navbar-wp .navbar-collapse,.wp-theme-1 .navbar-wp .navbar-form{border-color:#e7e7e7}.wp-theme-1 .navbar-wp .navbar-nav>.dropdown>a:hover .caret,.wp-theme-1 .navbar-wp .navbar-nav>.dropdown>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-1 .navbar-wp .dropdown-menu{min-width:220px;background:#FFF;border:0;border-top:1px solid #e91b23;border-bottom:3px solid #e91b23;border-radius:0}.wp-theme-1 .navbar-wp .dropdown-menu>li{border-bottom:1px solid #e0eded}.wp-theme-1 .navbar-wp .dropdown-menu>li:last-child{border:0}.wp-theme-1 .navbar-wp .dropdown-menu>li>a{color:#333;padding:8px 15px}.wp-theme-1 .navbar-wp .dropdown-menu>li>a:hover{background:#e91b23;color:#FFF}.wp-theme-1 .navbar-wp .dropdown-menu label.checkbox{color:#333}.wp-theme-1 .navbar-wp .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-1 .navbar-wp .dropdown-menu-user{border:1px solid #e0eded;border-top-color:transparent}.wp-theme-1 .navbar-wp .dropdown-menu-user{background:#fff}.wp-theme-1 .navbar-wp .navbar-right .dropdown-menu-user{background:#fff;border-color:transparent}.wp-theme-1 .navbar-wp .navbar-right .social-link{width:40px;height:40px;line-height:20px;text-align:center;padding:10px;margin:18px 0;border-radius:100%}.wp-theme-1 .navbar-wp .navbar-right .social-link.facebook:hover{background:#43609c;color:#fff}.wp-theme-1 .navbar-wp .navbar-right .social-link.pinterest:hover{background:#cb2027;color:#fff}.wp-theme-1 .navbar-wp .navbar-right .social-link.twitter:hover{background:#62addb;color:#fff}.wp-theme-1 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-1 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-1 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-1 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>.open>a,.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover,.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus{color:#FFF;background-color:#2c2c2c}.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>.open>a .caret,.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover .caret,.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none}.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:focus{background:none;color:#e91b23}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{bottom:100%;right:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-right:-35px}.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{bottom:100%;left:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-left:-35px}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu{min-width:220px;background:#2c2c2c;border:0;border-top:0;border-bottom:0;border-radius:0}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu>li{border-bottom:1px solid #262626}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu>li>a{color:#fff;padding:8px 15px}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu>li>a:hover{background:#e91b23;color:#FFF}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox{color:#fff}.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-1 .dropdown-submenu{position:relative}.wp-theme-1 .dropdown-submenu>.dropdown-menu{top:-5px;left:100%;margin-top:0;margin-left:-1px}.wp-theme-1 .dropdown-submenu:hover>.dropdown-menu{display:block}.wp-theme-1 .dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:3px 0 3px 3px;border-left-color:#ccc;margin-top:5px;margin-right:-6px}.wp-theme-1 .dropdown-submenu:hover>a:after{border-left-color:#fff}.wp-theme-1 .dropdown-submenu.pull-left{float:none}.wp-theme-1 .dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px}.wp-theme-1 .nav>ul{margin:0;padding:0;list-style:none}.wp-theme-1 .nav>ul>li{border-bottom:1px solid #333}.wp-theme-1 .nav>ul>li>a{display:block;padding:10px 15px;font-size:14px;color:#fff}.wp-theme-1 .nav>ul>li>a:hover{text-decoration:none;color:#e91b23;background:#292929}.wp-theme-1 .nav>ul>li>a>i{margin-right:5px}.wp-theme-1 .lw .pg-opt{border-bottom:1px solid #e0eded;background:#fcfcfc}.wp-theme-1 .ld .pg-opt{border-bottom:1px solid #444;background:#111}.wp-theme-1 .pg-opt.fixed{width:100%;position:fixed;top:0px;background:rgba(250,250,250,0.9);border-bottom:1px solid #e0eded;z-index:900}.wp-theme-1 .pg-opt h2{margin:0;padding:14px 0;font-size:22px;line-height:100%}.wp-theme-1 .pg-opt.fixed h2{margin-bottom:15px}.wp-theme-1 .pg-opt hr{margin:0;border-top-color:#dde1e6;-webkit-box-shadow:0 1px 0 #fbfbfc;-moz-box-shadow:0 1px 0 #fbfbfc;box-shadow:0 1px 0 #fbfbfc}.wp-theme-1 .pg-opt.fixed hr{display:none}.wp-theme-1 .pg-opt .breadcrumb{float:right;margin:0;padding:16px 0;background:none;border-radius:0}.wp-theme-1 .pg-opt .breadcrumb a{color:#e91b23}@media only screen and (max-width:767px){.wp-theme-1 .pg-opt .pg-nav{float:left;margin-bottom:10px}.wp-theme-1 .pg-opt h2{padding:20px 0 0 0}}.wp-theme-1 .page-header{margin:0;border:0}.wp-theme-1 .page-header p{font-size:16px}.wp-theme-1 .w-box{margin:0 0 15px 0;-webkit-transition:all 0.3s linear;transition:all 0.3s linear;position:relative;overflow:hidden;cursor:default;border:1px solid #e0eded}.wp-theme-1 .w-box:before,.wp-theme-1 .w-box:after{display:table;content:""}.wp-theme-1 .w-box:after{clear:both}.wp-theme-1 .w-box h1{margin:0;padding:10px 15px;font-weight:500;font-size:20px}.wp-theme-1 .lw .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#333}.wp-theme-1 .ld .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#fff}.wp-theme-1 .w-box.inner h2{padding:10px 0}.wp-theme-1 .w-box small{display:block;font-size:12px;margin-top:3px}.wp-theme-1 .w-box p{margin:6px 0;padding:0 15px;padding-bottom:8px}.wp-theme-1 .w-box time{display:block;padding:8px 15px 0 15px}.wp-theme-1 .w-box .w-footer{padding:10px 15px;border-top:1px solid #f1f1f1}.wp-theme-1 .w-box .w-footer:before,.wp-theme-1 .w-box .w-footer:after{display:table;content:""}.wp-theme-1 .w-box .w-footer:after{clear:both}.wp-theme-1 .w-box .w-footer small{font-size:12px}.wp-theme-1 .w-box .w-box-parent{-webkit-transition:all 0.3s linear;transition:all 0.3s linear}.wp-theme-1 .w-box .date-over{padding:10px;background:#fff;position:absolute;top:15px;right:15px;text-align:center;font-weight:normal}.wp-theme-1 .w-box .date-over.small{padding:4px 8px;font-size:12px}.wp-theme-1 .w-box .date-over strong{font-size:12px;display:block;font-weight:normal}.wp-theme-1 .w-box.dark{background:#333}.wp-theme-1 .w-box.dark h2{color:#fff}.wp-theme-1 .w-box.white h2{border-bottom:0;text-align:center}.wp-theme-1 .w-box.white .thmb-img{text-align:center;padding:15px 0}.wp-theme-1 .lw .w-box.white{background:#FFF}.wp-theme-1 .lw .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-1 .ld .w-box.white{background:#202020;border:1px solid #444}.wp-theme-1 .ld .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-1 .w-box.w-box-inverse .thmb-img i{width:100px;height:100px;border-radius:100px;font-size:34px;line-height:100px;text-align:center}.wp-theme-1 .lw .w-box.w-box-inverse .thmb-img i{background:#fcfcfc;color:#e91b23}.wp-theme-1 .ld .w-box.w-box-inverse .thmb-img i{background:#363636;color:#fff}.wp-theme-1 .w-box.w-box-inverse .thmb-img:hover i{background:#e91b23;color:#FFF}.wp-theme-1 .c-box{border:1px solid #e91b23}.wp-theme-1 .c-box .c-box-header{padding:10px 15px;background:#e91b23;color:#fff;font-size:16px;text-transform:capitalize}.wp-theme-1 .c-box .table{margin:0}.wp-theme-1 .ld .w-section h4,.wp-theme-1 .ld .w-section h3,.wp-theme-1 .ld .w-section h2{color:#fff}.wp-theme-1 .w-section .aside-feature{margin:10px;cursor:default}.wp-theme-1 .w-section .aside-feature .icon-feature{font-size:68px;margin-top:10px;text-align:center;display:block}.wp-theme-1 .w-section .aside-feature:hover .icon-feature,.wp-theme-1 .w-section .aside-feature:hover h4{color:#e91b23}.wp-theme-1 .w-section .aside-feature .img-feature{margin-top:4px;display:block}.wp-theme-1 .w-section .aside-feature .img-feature img{width:78px}.wp-theme-1 .layer-slider-wrapper{max-height:500px;overflow:hidden;border-bottom:1px solid #e0eded}.wp-theme-1 .layer-slider-wrapper .title{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-1 .layer-slider-wrapper .title.title-base{font-size:36px;line-height:46px;font-weight:500;color:#FFF;background:#e91b23;text-transform:capitalize}.wp-theme-1 .layer-slider-wrapper .title.title-dark{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-1 .layer-slider-wrapper .subtitle{font-size:22px;line-height:30px;color:#e91b23;text-transform:capitalize}.wp-theme-1 .layer-slider-wrapper .list-item{font-size:18px;line-height:30px;padding-left:30px;color:#e91b23;text-transform:capitalize}.wp-theme-1 .layer-slider-wrapper .text-standard{font-size:16px;line-height:22px}.wp-theme-1 .box-element{padding:20px}.wp-theme-1 .box-element:nth-child(n+1){margin-top:20px}.wp-theme-1 .box-element h1{margin:10px 0 !important;font-size:20px;line-height:26px;font-weight:400}.wp-theme-1 .box-element.box-element-bordered{background:transparent !important;border:1px solid #e91b23}.wp-theme-1 .box-element.box-element-outer{padding-left:0;padding-right:0}.wp-theme-1 .pricing-plans .plan-header .popular-tag{background:#333;border-bottom:1px solid #FFF;color:#fff}.wp-theme-1 .carousel-2{position:relative}.wp-theme-1 .carousel-2 .item{padding:36px 0 !important}.wp-theme-1 .carousel-2 .carousel-indicators{bottom:0}.wp-theme-1 .carousel-2 .carousel-indicators li{background-color:#f5f5f5;border:1px solid #ddd;border-radius:10px}.wp-theme-1 .carousel-2 .carousel-indicators .active{background-color:#e91b23}.wp-theme-1 .carousel-2 .img-thumbnail{margin-top:26px}.wp-theme-1 .carousel-2 h2{font-size:22px}.wp-theme-1 .carousel-2 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:10px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#e91b23;opacity:1}.wp-theme-1 .carousel-2 .carousel-nav a:hover{background:#e91b23 !important;color:#fff}.wp-theme-1 .carousel-2 .carousel-nav a.left{right:36px}.wp-theme-1 .carousel-2 .carousel-nav a.right{right:0}.wp-theme-1 .carousel-2 .carousel-control i{position:absolute;top:50%;font-size:22px;margin-top:-11px}.wp-theme-1 .carousel-2 .carousel-control.left i{left:18px}.wp-theme-1 .carousel-2 .carousel-control.right i{right:18px}.wp-theme-1 .carousel-3{position:relative}.wp-theme-1 .carousel-3 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:-50px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#e91b23;opacity:1}.wp-theme-1 .carousel-3 .carousel-nav a:hover{background:#e91b23 !important;color:#fff}.wp-theme-1 .carousel-3 .carousel-nav a.left{right:36px}.wp-theme-1 .carousel-3 .carousel-nav a.right{right:0}.wp-theme-1 .carousel-3 .carousel-nav a:hover{background:#FFF}.wp-theme-1 .carousel-testimonials{position:relative;border:1px solid #e0eded}.wp-theme-1 .like-button .button{display:block;text-align:right;padding-top:10px;color:#ddd}.wp-theme-1 .like-button .button i{font-size:20px;color:#ddd}.wp-theme-1 .like-button .button.liked i{color:#e91b23}.wp-theme-1 .like-button .count{display:block;text-align:right;position:relative;top:-7px}.wp-theme-1 .like-button.inline .button{display:inline-block;padding:0}.wp-theme-1 .like-button.inline .count{display:inline-block;top:-2px}.wp-theme-1 .like-button.inline .count small{font-size:13px}.wp-theme-1 .side-like-box{text-align:center;padding:5px 5px 0 5px;margin-top:10px}.wp-theme-1 .side-like-box .button{text-align:center;padding:0}.wp-theme-1 .side-like-box .count{text-align:center}.wp-theme-1 .side-like-box i{font-size:24px}.wp-theme-1 ul.list-listings{margin:0 0 20px 0;padding:0;list-style:none}.wp-theme-1 ul.list-listings li{margin-bottom:30px;border:1px solid #f3f3f3;overflow:hidden}.wp-theme-1 ul.list-listings li.featured{border-color:#e91b23}.wp-theme-1 ul.list-listings li:before,.wp-theme-1 ul.list-listings li:after{content:"";display:table}.wp-theme-1 ul.list-listings li:after{clear:both}.wp-theme-1 ul.list-listings .listing-header{clear:both;padding:8px 15px;font-weight:600;text-transform:uppercase}.wp-theme-1 ul.list-listings .listing-image{width:25%;height:150px;float:left;overflow:hidden}.wp-theme-1 ul.list-listings .listing-body{width:50%;height:150px;padding:15px;float:left;background:#fcfcfc;border-right:1px solid #fcfcfc}.wp-theme-1 ul.list-listings .listing-body h3{margin:0;padding:0;font-size:18px;font-weight:500;line-height:25px}.wp-theme-1 ul.list-listings .listing-body h4{font-size:14px;font-weight:normal;line-height:22px}.wp-theme-1 ul.list-listings .listing-actions{width:25%;height:110px;padding-top:40px;float:left;text-align:center}.wp-theme-1 ul.list-listings .listing-actions .btn{margin-top:6px}.wp-theme-1 ul.list-check{list-style:none;margin:0;margin-bottom:15px;padding:0}.wp-theme-1 ul.list-check li{padding:4px 0;margin:0;display:block;width:100%}.wp-theme-1 ul.list-check li i{color:#e91b23;font-style:normal;margin-right:4px}.wp-theme-1 ul.list-check li span{font-size:14px}.wp-theme-1 ul.categories{list-style:none;margin:0;padding:0 !important;border:1px solid #e0eded;overflow:hidden}.wp-theme-1 ul.categories li{border-bottom:1px solid #e0eded;position:reltive}.wp-theme-1 ul.categories li:last-child{border:0}.wp-theme-1 ul.categories li a{display:block;padding:10px 15px}.wp-theme-1 ul.categories li a:after{font-family:'FontAwesome';content:"\f105";position:relative;top:0;float:right}.wp-theme-1 ul.categories li a:hover{background:#e91b23;color:#FFF;text-decoration:none}.wp-theme-1 ul.categories li a i{display:inline-block;vertical-align:middle;padding-right:5px;font-style:normal;color:#999;font-size:11px}.wp-theme-1 ul.categories li a:hover i{color:#FFF}.wp-theme-1 .timeline .year{width:100%;background:#333;padding:8px 10px;margin:20px auto 40px !important;font-size:20px}.wp-theme-1 .timeline .year{border-radius:3px}.wp-theme-1 .timeline .event{padding:0;border:1px solid #e0eded;border-radius:0}.wp-theme-1 .timeline .event:nth-child(2n):before{content:"";display:inline-block;position:absolute;right:-6.8% !important;top:20px;width:10px;height:10px;background:#e91b23;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-1 .timeline .event:nth-child(2n-1):after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #FFF;border-top:12px solid transparent;border-bottom:12px solid transparent}.wp-theme-1 .timeline .event:nth-child(2n-1):before{content:"";display:inline-block;position:absolute;left:-6.5% !important;top:20px;width:10px;height:10px;background:#e91b23;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-1 .timeline .event-date{margin:0;background:#FFF;border-bottom:1px solid #e0eded;text-align:left;padding:10px 10px;font-weight:500;font-size:14px}.wp-theme-1 .timeline .event:nth-child(2n) .event-date:after{content:"";display:inline-block;position:absolute;right:-12px !important;top:12px;width:0;height:0;border-left:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-1 .timeline .event:nth-child(2n) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;right:-13px;width:0;height:0;border-left:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-1 .timeline .event:nth-child(2n-1) .event-date:after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-1 .timeline .event:nth-child(2n-1) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;left:-13px;width:0;height:0;border-right:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-1 .timeline .event-date small{display:block;font-size:12px;color:#a1a1a1;font-weight:normal}.wp-theme-1 .timeline .event-date i{margin-right:7px}.wp-theme-1 .timeline .event-body{background:#f8f8f8}.wp-theme-1 .timeline .event-footer{margin:0;text-align:left;padding:8px 10px;background:none;border-top:1px solid #e0eded}.wp-theme-1 .timeline .event-footer:after,.wp-theme-1 .timeline .event-footer:before{display:table;content:" "}.wp-theme-1 .timeline .event-footer:after{clear:both}.wp-theme-1 .timeline .event img{margin:0}.wp-theme-1 .timeline p{padding:20px 10px;text-align:left}.wp-theme-1 .timeline iframe{margin:10px 0 0 0}.wp-theme-1 #toTop{display:none;text-decoration:none;position:fixed;bottom:10px;right:10px;overflow:hidden;width:40px;height:40px;border:none;text-indent:100%;background:#555;border-radius:3px}.wp-theme-1 #toTopHover{background:#e91b23;width:40px;height:40px;display:block;overflow:hidden;float:left;opacity:0;-moz-opacity:0;filter:alpha(opacity=0)}.wp-theme-1 #toTop:active,.wp-theme-1 #toTop:focus{outline:none}.wp-theme-1 #toTop:before{font-family:'FontAwesome';content:"\f106";color:#ffffff;font-size:20px;position:absolute;top:50%;left:50%;width:20px;height:20px;text-align:center;line-height:20px;margin-top:-10px;margin-left:-10px;text-indent:0}.wp-theme-1 .widget.tags-wr{padding-bottom:15px}.wp-theme-1 .tags-list:before,.wp-theme-1 .tags-list:after{display:table;content:""}.wp-theme-1 .tags-list:after{clear:both}.wp-theme-1 .tags-list{list-style:none;padding-left:0;margin:0}.wp-theme-1 .tags-list li{border:1px solid #e91b23;background:#FFF;padding:5px;float:left;margin-right:5px;margin-bottom:5px;color:#e91b23;font-size:12px}.wp-theme-1 .tags-list li a{color:#e91b23;margin-left:4px}.wp-theme-1 .tags-list li:hover{background:#e91b23;color:#FFF}.wp-theme-1 .tags-list li:hover a{color:#FFF;text-decoration:none}.wp-theme-2 .btn{font-weight:normal;white-space:nowrap;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;border-radius:2px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.wp-theme-2 .btn i{margin-right:4px}.wp-theme-2 .btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:3px}.wp-theme-2 .btn-lg i{font-size:24px;position:relative;top:3px}.wp-theme-2 .btn-xs{padding:4px 10px}.wp-theme-2 .btn-one{background-color:none;border:2px solid #FFF;color:#FFF}.wp-theme-2 .btn-one:hover,.wp-theme-2 .btn-one:focus,.wp-theme-2 .btn-one:active,.wp-theme-2 .btn-one.active,.wp-theme-2 .open .dropdown-toggle.btn-one{color:#563d7c;background-color:#FFF;border-color:#FFF}.wp-theme-2 .btn-one:active,.wp-theme-2 .btn-one.active,.wp-theme-2 .open .dropdown-toggle.btn-one{background-image:none}.wp-theme-2 .btn-two{color:#ffffff;background-color:#563d7c;border:1px solid;border-color:#4c3372}.wp-theme-2 .btn-two:hover,.wp-theme-2 .btn-two:focus,.wp-theme-2 .btn-two:active,.wp-theme-2 .btn-two.active,.wp-theme-2 .open .dropdown-toggle.btn-two{color:#ffffff;background-color:#422968;border-color:#422968}.wp-theme-2 .btn-two:active,.wp-theme-2 .btn-two.active,.wp-theme-2 .open .dropdown-toggle.btn-two{background-image:none}.wp-theme-2 .btn-three{color:#ffffff;background-color:#333;border:1px solid;border-color:#292929}.wp-theme-2 .btn-three:hover,.wp-theme-2 .btn-three:focus,.wp-theme-2 .btn-three:active,.wp-theme-2 .btn-three.active,.wp-theme-2 .open .dropdown-toggle.btn-three{color:#ffffff;background-color:#1f1f1f;border-color:#1f1f1f}.wp-theme-2 .btn-three:active,.wp-theme-2 .btn-three.active,.wp-theme-2 .open .dropdown-toggle.btn-three{background-image:none}.wp-theme-2 .btn-four{background-color:none;border:2px solid #563d7c;color:#563d7c}.wp-theme-2 .btn-four:hover,.wp-theme-2 .btn-four:focus,.wp-theme-2 .btn-four:active,.wp-theme-2 .btn-four.active,.wp-theme-2 .open .dropdown-toggle.btn-four{color:#FFF;background-color:#563d7c}.wp-theme-2 .btn-four:active,.wp-theme-2 .btn-four.active,.wp-theme-2 .open .dropdown-toggle.btn-four{background-image:none}.wp-theme-2 h1,.wp-theme-2 h2,.wp-theme-2 h3,.wp-theme-2 h4,.wp-theme-2 h5,.wp-theme-2 h6{font-family:"Roboto",sans-serif !important}.wp-theme-2 p{line-height:22px}.wp-theme-2 a{color:#616161;cursor:pointer}.wp-theme-2 a:hover{color:#563d7c;text-decoration:none;-o-transition:.3s;-ms-transition:.3s;-moz-transition:.3s;-webkit-transition:.3s;transition:.35s}.wp-theme-2 .bg-2{background:#563d7c;color:#FFF}.wp-theme-2 .lw .bg-5{background:#fcfcfc;border-top:1px solid #e0eded;border-bottom:1px solid #e0eded}.wp-theme-2 .ld .bg-5{background:#363636;border-top:1px solid #444;border-bottom:1px solid #444}.wp-theme-2 .lw .bg-3{background:#fff;color:#616161}.wp-theme-2 .ld .bg-3{background:#202020;color:#888}.wp-theme-2 .bg-4{background:#333;color:#FFF}.wp-theme-2 .dark{background:#333;color:#FFF}.wp-theme-2 .red{background:#e91b23;color:#FFF}.wp-theme-2 .orange{background:#f39c12;color:#FFF}.wp-theme-2 .green{background:#f39c12;color:#FFF}.wp-theme-2 .blue{background:#3498db;color:#FFF}.wp-theme-2 .light{background:#fff;color:#616161 !important}.wp-theme-2 .blockquote-1:hover{border-color:#563d7c}.wp-theme-2 .blockquote-1 p{font-size:13px}.wp-theme-2 .section-title{display:inline-block;border-bottom:1px solid #333;margin:0 0 15px 0;padding:0 0 5px 0;font-size:20px;font-weight:500;text-transform:capitalize;position:relative;overflow:hidden}.wp-theme-2 .lw .section-title{color:#333}.wp-theme-2 .ld .section-title{color:#fff}.wp-theme-2 .section-title.white{color:#fff;border-bottom:1px solid #fff}.wp-theme-2 .navbar-wp{margin:0;padding:0;border:0;border-radius:0;z-index:1000}.wp-theme-2 .lw .navbar-wp{background:#fff;border-bottom:1px solid #e0eded}.wp-theme-2 .ld .navbar-wp{background:#181818;border-bottom:1px solid #444}.wp-theme-2 .ld .sticky-wrapper .navbar-wp{background:rgba(24,24,24,0.85);border-bottom:1px solid #444}.wp-theme-2 .navbar-wp .navbar-nav>li>a{padding:28px 16px;margin-right:0;font-size:15px;font-weight:normal}.wp-theme-2 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-2 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-2 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-2 .lw .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#333}.wp-theme-2 .lw .navbar-wp .navbar-nav>li>a:hover,.wp-theme-2 .lw .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#563d7c}.wp-theme-2 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-2 .ld .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#fff}.wp-theme-2 .ld .navbar-wp .navbar-nav>li>a:hover,.wp-theme-2 .ld .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#563d7c}.wp-theme-2 .navbar-wp .navbar-nav>.active>a,.wp-theme-2 .navbar-wp .navbar-nav>.active>a:hover,.wp-theme-2 .navbar-wp .navbar-nav>.active>a:focus{color:#fff !important;background-color:#563d7c;border-radius:0}.wp-theme-2 .navbar-wp .navbar-nav>.disabled>a,.wp-theme-2 .navbar-wp .navbar-nav>.disabled>a:hover,.wp-theme-2 .navbar-wp .navbar-nav>.disabled>a:focus{color:#cccccc;background-color:transparent}.wp-theme-2 .navbar-wp .navbar-nav>.open>a,.wp-theme-2 .navbar-wp .navbar-nav>.open>a:hover,.wp-theme-2 .navbar-wp .navbar-nav>.open>a:focus{color:#FFF !important;background-color:#563d7c}.wp-theme-2 .navbar-wp .navbar-nav>.open>a .caret,.wp-theme-2 .navbar-wp .navbar-nav>.open>a:hover .caret,.wp-theme-2 .navbar-wp .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-2 .navbar-wp .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-2 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle,.wp-theme-2 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-2 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:focus{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none;color:#563d7c}.wp-theme-2 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle,.wp-theme-2 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:hover,.wp-theme-2 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:focus{color:#563d7c !important;background-color:none}.wp-theme-2 .navbar-wp .navbar-toggle{border-color:#333;margin-top:20px}.wp-theme-2 .navbar-wp .navbar-toggle .icon-bar{background-color:#4c4c4c}.wp-theme-2 .navbar-wp .navbar-toggle .icon-custom{font-size:18px}.wp-theme-2 .navbar-wp .navbar-toggle:hover,.wp-theme-2 .navbar-wp .navbar-toggle:focus{background-color:#563d7c;border-color:#563d7c}.wp-theme-2 .navbar-wp .navbar-toggle:hover .icon-bar,.wp-theme-2 .navbar-wp .navbar-toggle:focus .icon-bar{background-color:#FFF}.wp-theme-2 .navbar-wp .navbar-toggle:hover .icon-custom,.wp-theme-2 .navbar-wp .navbar-toggle:focus .icon-custom{color:#FFF}.wp-theme-2 .navbar-wp .navbar-toggle-aside-menu{padding:8px 10px 2px 10px}.wp-theme-2 .navbar-wp .navbar-collapse,.wp-theme-2 .navbar-wp .navbar-form{border-color:#e7e7e7}.wp-theme-2 .navbar-wp .navbar-nav>.dropdown>a:hover .caret,.wp-theme-2 .navbar-wp .navbar-nav>.dropdown>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-2 .navbar-wp .dropdown-menu{min-width:220px;background:#FFF;border:0;border-top:1px solid #563d7c;border-bottom:3px solid #563d7c;border-radius:0}.wp-theme-2 .navbar-wp .dropdown-menu>li{border-bottom:1px solid #e0eded}.wp-theme-2 .navbar-wp .dropdown-menu>li:last-child{border:0}.wp-theme-2 .navbar-wp .dropdown-menu>li>a{color:#333;padding:8px 15px}.wp-theme-2 .navbar-wp .dropdown-menu>li>a:hover{background:#563d7c;color:#FFF}.wp-theme-2 .navbar-wp .dropdown-menu label.checkbox{color:#333}.wp-theme-2 .navbar-wp .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-2 .navbar-wp .dropdown-menu-user{border:1px solid #e0eded;border-top-color:transparent}.wp-theme-2 .navbar-wp .dropdown-menu-user{background:#fff}.wp-theme-2 .navbar-wp .navbar-right .dropdown-menu-user{background:#fff;border-color:transparent}.wp-theme-2 .navbar-wp .navbar-right .social-link{width:40px;height:40px;line-height:20px;text-align:center;padding:10px;margin:18px 0;border-radius:100%}.wp-theme-2 .navbar-wp .navbar-right .social-link.facebook:hover{background:#43609c;color:#fff}.wp-theme-2 .navbar-wp .navbar-right .social-link.pinterest:hover{background:#cb2027;color:#fff}.wp-theme-2 .navbar-wp .navbar-right .social-link.twitter:hover{background:#62addb;color:#fff}.wp-theme-2 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-2 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-2 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-2 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>.open>a,.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover,.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus{color:#FFF;background-color:#2c2c2c}.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>.open>a .caret,.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover .caret,.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none}.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:focus{background:none;color:#563d7c}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{bottom:100%;right:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-right:-35px}.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{bottom:100%;left:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-left:-35px}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu{min-width:220px;background:#2c2c2c;border:0;border-top:0;border-bottom:0;border-radius:0}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu>li{border-bottom:1px solid #262626}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu>li>a{color:#fff;padding:8px 15px}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu>li>a:hover{background:#563d7c;color:#FFF}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox{color:#fff}.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-2 .dropdown-submenu{position:relative}.wp-theme-2 .dropdown-submenu>.dropdown-menu{top:-5px;left:100%;margin-top:0;margin-left:-1px}.wp-theme-2 .dropdown-submenu:hover>.dropdown-menu{display:block}.wp-theme-2 .dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:3px 0 3px 3px;border-left-color:#ccc;margin-top:5px;margin-right:-6px}.wp-theme-2 .dropdown-submenu:hover>a:after{border-left-color:#fff}.wp-theme-2 .dropdown-submenu.pull-left{float:none}.wp-theme-2 .dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px}.wp-theme-2 .nav>ul{margin:0;padding:0;list-style:none}.wp-theme-2 .nav>ul>li{border-bottom:1px solid #333}.wp-theme-2 .nav>ul>li>a{display:block;padding:10px 15px;font-size:14px;color:#fff}.wp-theme-2 .nav>ul>li>a:hover{text-decoration:none;color:#563d7c;background:#292929}.wp-theme-2 .nav>ul>li>a>i{margin-right:5px}.wp-theme-2 .lw .pg-opt{border-bottom:1px solid #e0eded;background:#fcfcfc}.wp-theme-2 .ld .pg-opt{border-bottom:1px solid #444;background:#111}.wp-theme-2 .pg-opt.fixed{width:100%;position:fixed;top:0px;background:rgba(250,250,250,0.9);border-bottom:1px solid #e0eded;z-index:900}.wp-theme-2 .pg-opt h2{margin:0;padding:14px 0;font-size:22px;line-height:100%}.wp-theme-2 .pg-opt.fixed h2{margin-bottom:15px}.wp-theme-2 .pg-opt hr{margin:0;border-top-color:#dde1e6;-webkit-box-shadow:0 1px 0 #fbfbfc;-moz-box-shadow:0 1px 0 #fbfbfc;box-shadow:0 1px 0 #fbfbfc}.wp-theme-2 .pg-opt.fixed hr{display:none}.wp-theme-2 .pg-opt .breadcrumb{float:right;margin:0;padding:16px 0;background:none;border-radius:0}.wp-theme-2 .pg-opt .breadcrumb a{color:#563d7c}@media only screen and (max-width:767px){.wp-theme-2 .pg-opt .pg-nav{float:left;margin-bottom:10px}.wp-theme-2 .pg-opt h2{padding:20px 0 0 0}}.wp-theme-2 .page-header{margin:0;border:0}.wp-theme-2 .page-header p{font-size:16px}.wp-theme-2 .w-box{margin:0 0 15px 0;-webkit-transition:all 0.3s linear;transition:all 0.3s linear;position:relative;overflow:hidden;cursor:default;border:1px solid #e0eded}.wp-theme-2 .w-box:before,.wp-theme-2 .w-box:after{display:table;content:""}.wp-theme-2 .w-box:after{clear:both}.wp-theme-2 .w-box h1{margin:0;padding:10px 15px;font-weight:500;font-size:20px}.wp-theme-2 .lw .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#333}.wp-theme-2 .ld .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#fff}.wp-theme-2 .w-box.inner h2{padding:10px 0}.wp-theme-2 .w-box small{display:block;font-size:12px;margin-top:3px}.wp-theme-2 .w-box p{margin:6px 0;padding:0 15px;padding-bottom:8px}.wp-theme-2 .w-box time{display:block;padding:8px 15px 0 15px}.wp-theme-2 .w-box .w-footer{padding:10px 15px;border-top:1px solid #f1f1f1}.wp-theme-2 .w-box .w-footer:before,.wp-theme-2 .w-box .w-footer:after{display:table;content:""}.wp-theme-2 .w-box .w-footer:after{clear:both}.wp-theme-2 .w-box .w-footer small{font-size:12px}.wp-theme-2 .w-box .w-box-parent{-webkit-transition:all 0.3s linear;transition:all 0.3s linear}.wp-theme-2 .w-box .date-over{padding:10px;background:#fff;position:absolute;top:15px;right:15px;text-align:center;font-weight:normal}.wp-theme-2 .w-box .date-over.small{padding:4px 8px;font-size:12px}.wp-theme-2 .w-box .date-over strong{font-size:12px;display:block;font-weight:normal}.wp-theme-2 .w-box.dark{background:#333}.wp-theme-2 .w-box.dark h2{color:#fff}.wp-theme-2 .w-box.white h2{border-bottom:0;text-align:center}.wp-theme-2 .w-box.white .thmb-img{text-align:center;padding:15px 0}.wp-theme-2 .lw .w-box.white{background:#FFF}.wp-theme-2 .lw .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-2 .ld .w-box.white{background:#202020;border:1px solid #444}.wp-theme-2 .ld .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-2 .w-box.w-box-inverse .thmb-img i{width:100px;height:100px;border-radius:100px;font-size:34px;line-height:100px;text-align:center}.wp-theme-2 .lw .w-box.w-box-inverse .thmb-img i{background:#fcfcfc;color:#563d7c}.wp-theme-2 .ld .w-box.w-box-inverse .thmb-img i{background:#363636;color:#fff}.wp-theme-2 .w-box.w-box-inverse .thmb-img:hover i{background:#563d7c;color:#FFF}.wp-theme-2 .c-box{border:1px solid #563d7c}.wp-theme-2 .c-box .c-box-header{padding:10px 15px;background:#563d7c;color:#fff;font-size:16px;text-transform:capitalize}.wp-theme-2 .c-box .table{margin:0}.wp-theme-2 .ld .w-section h4,.wp-theme-2 .ld .w-section h3,.wp-theme-2 .ld .w-section h2{color:#fff}.wp-theme-2 .w-section .aside-feature{margin:10px;cursor:default}.wp-theme-2 .w-section .aside-feature .icon-feature{font-size:68px;margin-top:10px;text-align:center;display:block}.wp-theme-2 .w-section .aside-feature:hover .icon-feature,.wp-theme-2 .w-section .aside-feature:hover h4{color:#563d7c}.wp-theme-2 .w-section .aside-feature .img-feature{margin-top:4px;display:block}.wp-theme-2 .w-section .aside-feature .img-feature img{width:78px}.wp-theme-2 .layer-slider-wrapper{max-height:500px;overflow:hidden;border-bottom:1px solid #e0eded}.wp-theme-2 .layer-slider-wrapper .title{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-2 .layer-slider-wrapper .title.title-base{font-size:36px;line-height:46px;font-weight:500;color:#FFF;background:#e91b23;text-transform:capitalize}.wp-theme-2 .layer-slider-wrapper .title.title-dark{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-2 .layer-slider-wrapper .subtitle{font-size:22px;line-height:30px;color:#563d7c;text-transform:capitalize}.wp-theme-2 .layer-slider-wrapper .list-item{font-size:18px;line-height:30px;padding-left:30px;color:#563d7c;text-transform:capitalize}.wp-theme-2 .layer-slider-wrapper .text-standard{font-size:16px;line-height:22px}.wp-theme-2 .box-element{padding:20px}.wp-theme-2 .box-element:nth-child(n+1){margin-top:20px}.wp-theme-2 .box-element h1{margin:10px 0 !important;font-size:20px;line-height:26px;font-weight:400}.wp-theme-2 .box-element.box-element-bordered{background:transparent !important;border:1px solid #563d7c}.wp-theme-2 .box-element.box-element-outer{padding-left:0;padding-right:0}.wp-theme-2 .pricing-plans .plan-header .popular-tag{background:#333;border-bottom:1px solid #FFF;color:#fff}.wp-theme-2 .carousel-2{position:relative}.wp-theme-2 .carousel-2 .item{padding:36px 0 !important}.wp-theme-2 .carousel-2 .carousel-indicators{bottom:0}.wp-theme-2 .carousel-2 .carousel-indicators li{background-color:#f5f5f5;border:1px solid #ddd;border-radius:10px}.wp-theme-2 .carousel-2 .carousel-indicators .active{background-color:#563d7c}.wp-theme-2 .carousel-2 .img-thumbnail{margin-top:26px}.wp-theme-2 .carousel-2 h2{font-size:22px}.wp-theme-2 .carousel-2 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:10px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#563d7c;opacity:1}.wp-theme-2 .carousel-2 .carousel-nav a:hover{background:#563d7c !important;color:#fff}.wp-theme-2 .carousel-2 .carousel-nav a.left{right:36px}.wp-theme-2 .carousel-2 .carousel-nav a.right{right:0}.wp-theme-2 .carousel-2 .carousel-control i{position:absolute;top:50%;font-size:22px;margin-top:-11px}.wp-theme-2 .carousel-2 .carousel-control.left i{left:18px}.wp-theme-2 .carousel-2 .carousel-control.right i{right:18px}.wp-theme-2 .carousel-3{position:relative}.wp-theme-2 .carousel-3 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:-50px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#563d7c;opacity:1}.wp-theme-2 .carousel-3 .carousel-nav a:hover{background:#563d7c !important;color:#fff}.wp-theme-2 .carousel-3 .carousel-nav a.left{right:36px}.wp-theme-2 .carousel-3 .carousel-nav a.right{right:0}.wp-theme-2 .carousel-3 .carousel-nav a:hover{background:#FFF}.wp-theme-2 .carousel-testimonials{position:relative;border:1px solid #e0eded}.wp-theme-2 .like-button .button{display:block;text-align:right;padding-top:10px;color:#ddd}.wp-theme-2 .like-button .button i{font-size:20px;color:#ddd}.wp-theme-2 .like-button .button.liked i{color:#563d7c}.wp-theme-2 .like-button .count{display:block;text-align:right;position:relative;top:-7px}.wp-theme-2 .like-button.inline .button{display:inline-block;padding:0}.wp-theme-2 .like-button.inline .count{display:inline-block;top:-2px}.wp-theme-2 .like-button.inline .count small{font-size:13px}.wp-theme-2 .side-like-box{text-align:center;padding:5px 5px 0 5px;margin-top:10px}.wp-theme-2 .side-like-box .button{text-align:center;padding:0}.wp-theme-2 .side-like-box .count{text-align:center}.wp-theme-2 .side-like-box i{font-size:24px}.wp-theme-2 ul.list-listings{margin:0 0 20px 0;padding:0;list-style:none}.wp-theme-2 ul.list-listings li{margin-bottom:30px;border:1px solid #f3f3f3;overflow:hidden}.wp-theme-2 ul.list-listings li.featured{border-color:#563d7c}.wp-theme-2 ul.list-listings li:before,.wp-theme-2 ul.list-listings li:after{content:"";display:table}.wp-theme-2 ul.list-listings li:after{clear:both}.wp-theme-2 ul.list-listings .listing-header{clear:both;padding:8px 15px;font-weight:600;text-transform:uppercase}.wp-theme-2 ul.list-listings .listing-image{width:25%;height:150px;float:left;overflow:hidden}.wp-theme-2 ul.list-listings .listing-body{width:50%;height:150px;padding:15px;float:left;background:#fcfcfc;border-right:1px solid #fcfcfc}.wp-theme-2 ul.list-listings .listing-body h3{margin:0;padding:0;font-size:18px;font-weight:500;line-height:25px}.wp-theme-2 ul.list-listings .listing-body h4{font-size:14px;font-weight:normal;line-height:22px}.wp-theme-2 ul.list-listings .listing-actions{width:25%;height:110px;padding-top:40px;float:left;text-align:center}.wp-theme-2 ul.list-listings .listing-actions .btn{margin-top:6px}.wp-theme-2 ul.list-check{list-style:none;margin:0;margin-bottom:15px;padding:0}.wp-theme-2 ul.list-check li{padding:4px 0;margin:0;display:block;width:100%}.wp-theme-2 ul.list-check li i{color:#563d7c;font-style:normal;margin-right:4px}.wp-theme-2 ul.list-check li span{font-size:14px}.wp-theme-2 ul.categories{list-style:none;margin:0;padding:0 !important;border:1px solid #e0eded;overflow:hidden}.wp-theme-2 ul.categories li{border-bottom:1px solid #e0eded;position:reltive}.wp-theme-2 ul.categories li:last-child{border:0}.wp-theme-2 ul.categories li a{display:block;padding:10px 15px}.wp-theme-2 ul.categories li a:after{font-family:'FontAwesome';content:"\f105";position:relative;top:0;float:right}.wp-theme-2 ul.categories li a:hover{background:#563d7c;color:#FFF;text-decoration:none}.wp-theme-2 ul.categories li a i{display:inline-block;vertical-align:middle;padding-right:5px;font-style:normal;color:#999;font-size:11px}.wp-theme-2 ul.categories li a:hover i{color:#FFF}.wp-theme-2 .timeline .year{width:100%;background:#333;padding:8px 10px;margin:20px auto 40px !important;font-size:20px}.wp-theme-2 .timeline .year{border-radius:3px}.wp-theme-2 .timeline .event{padding:0;border:1px solid #e0eded;border-radius:0}.wp-theme-2 .timeline .event:nth-child(2n):before{content:"";display:inline-block;position:absolute;right:-6.8% !important;top:20px;width:10px;height:10px;background:#563d7c;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-2 .timeline .event:nth-child(2n-1):after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #FFF;border-top:12px solid transparent;border-bottom:12px solid transparent}.wp-theme-2 .timeline .event:nth-child(2n-1):before{content:"";display:inline-block;position:absolute;left:-6.5% !important;top:20px;width:10px;height:10px;background:#563d7c;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-2 .timeline .event-date{margin:0;background:#FFF;border-bottom:1px solid #e0eded;text-align:left;padding:10px 10px;font-weight:500;font-size:14px}.wp-theme-2 .timeline .event:nth-child(2n) .event-date:after{content:"";display:inline-block;position:absolute;right:-12px !important;top:12px;width:0;height:0;border-left:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-2 .timeline .event:nth-child(2n) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;right:-13px;width:0;height:0;border-left:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-2 .timeline .event:nth-child(2n-1) .event-date:after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-2 .timeline .event:nth-child(2n-1) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;left:-13px;width:0;height:0;border-right:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-2 .timeline .event-date small{display:block;font-size:12px;color:#a1a1a1;font-weight:normal}.wp-theme-2 .timeline .event-date i{margin-right:7px}.wp-theme-2 .timeline .event-body{background:#f8f8f8}.wp-theme-2 .timeline .event-footer{margin:0;text-align:left;padding:8px 10px;background:none;border-top:1px solid #e0eded}.wp-theme-2 .timeline .event-footer:after,.wp-theme-2 .timeline .event-footer:before{display:table;content:" "}.wp-theme-2 .timeline .event-footer:after{clear:both}.wp-theme-2 .timeline .event img{margin:0}.wp-theme-2 .timeline p{padding:20px 10px;text-align:left}.wp-theme-2 .timeline iframe{margin:10px 0 0 0}.wp-theme-2 #toTop{display:none;text-decoration:none;position:fixed;bottom:10px;right:10px;overflow:hidden;width:40px;height:40px;border:none;text-indent:100%;background:#555;border-radius:3px}.wp-theme-2 #toTopHover{background:#563d7c;width:40px;height:40px;display:block;overflow:hidden;float:left;opacity:0;-moz-opacity:0;filter:alpha(opacity=0)}.wp-theme-2 #toTop:active,.wp-theme-2 #toTop:focus{outline:none}.wp-theme-2 #toTop:before{font-family:'FontAwesome';content:"\f106";color:#ffffff;font-size:20px;position:absolute;top:50%;left:50%;width:20px;height:20px;text-align:center;line-height:20px;margin-top:-10px;margin-left:-10px;text-indent:0}.wp-theme-2 .widget.tags-wr{padding-bottom:15px}.wp-theme-2 .tags-list:before,.wp-theme-2 .tags-list:after{display:table;content:""}.wp-theme-2 .tags-list:after{clear:both}.wp-theme-2 .tags-list{list-style:none;padding-left:0;margin:0}.wp-theme-2 .tags-list li{border:1px solid #563d7c;background:#FFF;padding:5px;float:left;margin-right:5px;margin-bottom:5px;color:#563d7c;font-size:12px}.wp-theme-2 .tags-list li a{color:#563d7c;margin-left:4px}.wp-theme-2 .tags-list li:hover{background:#563d7c;color:#FFF}.wp-theme-2 .tags-list li:hover a{color:#FFF;text-decoration:none}.wp-theme-3 .btn{font-weight:normal;white-space:nowrap;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;border-radius:2px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.wp-theme-3 .btn i{margin-right:4px}.wp-theme-3 .btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:3px}.wp-theme-3 .btn-lg i{font-size:24px;position:relative;top:3px}.wp-theme-3 .btn-xs{padding:4px 10px}.wp-theme-3 .btn-one{background-color:none;border:2px solid #FFF;color:#FFF}.wp-theme-3 .btn-one:hover,.wp-theme-3 .btn-one:focus,.wp-theme-3 .btn-one:active,.wp-theme-3 .btn-one.active,.wp-theme-3 .open .dropdown-toggle.btn-one{color:#59b2e5;background-color:#FFF;border-color:#FFF}.wp-theme-3 .btn-one:active,.wp-theme-3 .btn-one.active,.wp-theme-3 .open .dropdown-toggle.btn-one{background-image:none}.wp-theme-3 .btn-two{color:#ffffff;background-color:#59b2e5;border:1px solid;border-color:#4fa8db}.wp-theme-3 .btn-two:hover,.wp-theme-3 .btn-two:focus,.wp-theme-3 .btn-two:active,.wp-theme-3 .btn-two.active,.wp-theme-3 .open .dropdown-toggle.btn-two{color:#ffffff;background-color:#459ed1;border-color:#459ed1}.wp-theme-3 .btn-two:active,.wp-theme-3 .btn-two.active,.wp-theme-3 .open .dropdown-toggle.btn-two{background-image:none}.wp-theme-3 .btn-three{color:#ffffff;background-color:#333;border:1px solid;border-color:#292929}.wp-theme-3 .btn-three:hover,.wp-theme-3 .btn-three:focus,.wp-theme-3 .btn-three:active,.wp-theme-3 .btn-three.active,.wp-theme-3 .open .dropdown-toggle.btn-three{color:#ffffff;background-color:#1f1f1f;border-color:#1f1f1f}.wp-theme-3 .btn-three:active,.wp-theme-3 .btn-three.active,.wp-theme-3 .open .dropdown-toggle.btn-three{background-image:none}.wp-theme-3 .btn-four{background-color:none;border:2px solid #59b2e5;color:#59b2e5}.wp-theme-3 .btn-four:hover,.wp-theme-3 .btn-four:focus,.wp-theme-3 .btn-four:active,.wp-theme-3 .btn-four.active,.wp-theme-3 .open .dropdown-toggle.btn-four{color:#FFF;background-color:#59b2e5}.wp-theme-3 .btn-four:active,.wp-theme-3 .btn-four.active,.wp-theme-3 .open .dropdown-toggle.btn-four{background-image:none}.wp-theme-3 h1,.wp-theme-3 h2,.wp-theme-3 h3,.wp-theme-3 h4,.wp-theme-3 h5,.wp-theme-3 h6{font-family:"Roboto",sans-serif !important}.wp-theme-3 p{line-height:22px}.wp-theme-3 a{color:#616161;cursor:pointer}.wp-theme-3 a:hover{color:#59b2e5;text-decoration:none;-o-transition:.3s;-ms-transition:.3s;-moz-transition:.3s;-webkit-transition:.3s;transition:.35s}.wp-theme-3 .bg-2{background:#59b2e5;color:#FFF}.wp-theme-3 .lw .bg-5{background:#fcfcfc;border-top:1px solid #e0eded;border-bottom:1px solid #e0eded}.wp-theme-3 .ld .bg-5{background:#363636;border-top:1px solid #444;border-bottom:1px solid #444}.wp-theme-3 .lw .bg-3{background:#fff;color:#616161}.wp-theme-3 .ld .bg-3{background:#202020;color:#888}.wp-theme-3 .bg-4{background:#333;color:#FFF}.wp-theme-3 .dark{background:#333;color:#FFF}.wp-theme-3 .red{background:#e91b23;color:#FFF}.wp-theme-3 .orange{background:#f39c12;color:#FFF}.wp-theme-3 .green{background:#f39c12;color:#FFF}.wp-theme-3 .blue{background:#3498db;color:#FFF}.wp-theme-3 .light{background:#fff;color:#616161 !important}.wp-theme-3 .blockquote-1:hover{border-color:#59b2e5}.wp-theme-3 .blockquote-1 p{font-size:13px}.wp-theme-3 .section-title{display:inline-block;border-bottom:1px solid #333;margin:0 0 15px 0;padding:0 0 5px 0;font-size:20px;font-weight:500;text-transform:capitalize;position:relative;overflow:hidden}.wp-theme-3 .lw .section-title{color:#333}.wp-theme-3 .ld .section-title{color:#fff}.wp-theme-3 .section-title.white{color:#fff;border-bottom:1px solid #fff}.wp-theme-3 .navbar-wp{margin:0;padding:0;border:0;border-radius:0;z-index:1000}.wp-theme-3 .lw .navbar-wp{background:#fff;border-bottom:1px solid #e0eded}.wp-theme-3 .ld .navbar-wp{background:#181818;border-bottom:1px solid #444}.wp-theme-3 .ld .sticky-wrapper .navbar-wp{background:rgba(24,24,24,0.85);border-bottom:1px solid #444}.wp-theme-3 .navbar-wp .navbar-nav>li>a{padding:28px 16px;margin-right:0;font-size:15px;font-weight:normal}.wp-theme-3 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-3 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-3 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-3 .lw .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#333}.wp-theme-3 .lw .navbar-wp .navbar-nav>li>a:hover,.wp-theme-3 .lw .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#59b2e5}.wp-theme-3 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-3 .ld .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#fff}.wp-theme-3 .ld .navbar-wp .navbar-nav>li>a:hover,.wp-theme-3 .ld .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#59b2e5}.wp-theme-3 .navbar-wp .navbar-nav>.active>a,.wp-theme-3 .navbar-wp .navbar-nav>.active>a:hover,.wp-theme-3 .navbar-wp .navbar-nav>.active>a:focus{color:#fff !important;background-color:#59b2e5;border-radius:0}.wp-theme-3 .navbar-wp .navbar-nav>.disabled>a,.wp-theme-3 .navbar-wp .navbar-nav>.disabled>a:hover,.wp-theme-3 .navbar-wp .navbar-nav>.disabled>a:focus{color:#cccccc;background-color:transparent}.wp-theme-3 .navbar-wp .navbar-nav>.open>a,.wp-theme-3 .navbar-wp .navbar-nav>.open>a:hover,.wp-theme-3 .navbar-wp .navbar-nav>.open>a:focus{color:#FFF !important;background-color:#59b2e5}.wp-theme-3 .navbar-wp .navbar-nav>.open>a .caret,.wp-theme-3 .navbar-wp .navbar-nav>.open>a:hover .caret,.wp-theme-3 .navbar-wp .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-3 .navbar-wp .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-3 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle,.wp-theme-3 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-3 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:focus{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none;color:#59b2e5}.wp-theme-3 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle,.wp-theme-3 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:hover,.wp-theme-3 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:focus{color:#59b2e5 !important;background-color:none}.wp-theme-3 .navbar-wp .navbar-toggle{border-color:#333;margin-top:20px}.wp-theme-3 .navbar-wp .navbar-toggle .icon-bar{background-color:#4c4c4c}.wp-theme-3 .navbar-wp .navbar-toggle .icon-custom{font-size:18px}.wp-theme-3 .navbar-wp .navbar-toggle:hover,.wp-theme-3 .navbar-wp .navbar-toggle:focus{background-color:#59b2e5;border-color:#59b2e5}.wp-theme-3 .navbar-wp .navbar-toggle:hover .icon-bar,.wp-theme-3 .navbar-wp .navbar-toggle:focus .icon-bar{background-color:#FFF}.wp-theme-3 .navbar-wp .navbar-toggle:hover .icon-custom,.wp-theme-3 .navbar-wp .navbar-toggle:focus .icon-custom{color:#FFF}.wp-theme-3 .navbar-wp .navbar-toggle-aside-menu{padding:8px 10px 2px 10px}.wp-theme-3 .navbar-wp .navbar-collapse,.wp-theme-3 .navbar-wp .navbar-form{border-color:#e7e7e7}.wp-theme-3 .navbar-wp .navbar-nav>.dropdown>a:hover .caret,.wp-theme-3 .navbar-wp .navbar-nav>.dropdown>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-3 .navbar-wp .dropdown-menu{min-width:220px;background:#FFF;border:0;border-top:1px solid #59b2e5;border-bottom:3px solid #59b2e5;border-radius:0}.wp-theme-3 .navbar-wp .dropdown-menu>li{border-bottom:1px solid #e0eded}.wp-theme-3 .navbar-wp .dropdown-menu>li:last-child{border:0}.wp-theme-3 .navbar-wp .dropdown-menu>li>a{color:#333;padding:8px 15px}.wp-theme-3 .navbar-wp .dropdown-menu>li>a:hover{background:#59b2e5;color:#FFF}.wp-theme-3 .navbar-wp .dropdown-menu label.checkbox{color:#333}.wp-theme-3 .navbar-wp .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-3 .navbar-wp .dropdown-menu-user{border:1px solid #e0eded;border-top-color:transparent}.wp-theme-3 .navbar-wp .dropdown-menu-user{background:#fff}.wp-theme-3 .navbar-wp .navbar-right .dropdown-menu-user{background:#fff;border-color:transparent}.wp-theme-3 .navbar-wp .navbar-right .social-link{width:40px;height:40px;line-height:20px;text-align:center;padding:10px;margin:18px 0;border-radius:100%}.wp-theme-3 .navbar-wp .navbar-right .social-link.facebook:hover{background:#43609c;color:#fff}.wp-theme-3 .navbar-wp .navbar-right .social-link.pinterest:hover{background:#cb2027;color:#fff}.wp-theme-3 .navbar-wp .navbar-right .social-link.twitter:hover{background:#62addb;color:#fff}.wp-theme-3 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-3 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-3 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-3 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>.open>a,.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover,.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus{color:#FFF;background-color:#2c2c2c}.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>.open>a .caret,.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover .caret,.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none}.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:focus{background:none;color:#59b2e5}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{bottom:100%;right:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-right:-35px}.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{bottom:100%;left:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-left:-35px}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu{min-width:220px;background:#2c2c2c;border:0;border-top:0;border-bottom:0;border-radius:0}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu>li{border-bottom:1px solid #262626}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu>li>a{color:#fff;padding:8px 15px}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu>li>a:hover{background:#59b2e5;color:#FFF}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox{color:#fff}.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-3 .dropdown-submenu{position:relative}.wp-theme-3 .dropdown-submenu>.dropdown-menu{top:-5px;left:100%;margin-top:0;margin-left:-1px}.wp-theme-3 .dropdown-submenu:hover>.dropdown-menu{display:block}.wp-theme-3 .dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:3px 0 3px 3px;border-left-color:#ccc;margin-top:5px;margin-right:-6px}.wp-theme-3 .dropdown-submenu:hover>a:after{border-left-color:#fff}.wp-theme-3 .dropdown-submenu.pull-left{float:none}.wp-theme-3 .dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px}.wp-theme-3 .nav>ul{margin:0;padding:0;list-style:none}.wp-theme-3 .nav>ul>li{border-bottom:1px solid #333}.wp-theme-3 .nav>ul>li>a{display:block;padding:10px 15px;font-size:14px;color:#fff}.wp-theme-3 .nav>ul>li>a:hover{text-decoration:none;color:#59b2e5;background:#292929}.wp-theme-3 .nav>ul>li>a>i{margin-right:5px}.wp-theme-3 .lw .pg-opt{border-bottom:1px solid #e0eded;background:#fcfcfc}.wp-theme-3 .ld .pg-opt{border-bottom:1px solid #444;background:#111}.wp-theme-3 .pg-opt.fixed{width:100%;position:fixed;top:0px;background:rgba(250,250,250,0.9);border-bottom:1px solid #e0eded;z-index:900}.wp-theme-3 .pg-opt h2{margin:0;padding:14px 0;font-size:22px;line-height:100%}.wp-theme-3 .pg-opt.fixed h2{margin-bottom:15px}.wp-theme-3 .pg-opt hr{margin:0;border-top-color:#dde1e6;-webkit-box-shadow:0 1px 0 #fbfbfc;-moz-box-shadow:0 1px 0 #fbfbfc;box-shadow:0 1px 0 #fbfbfc}.wp-theme-3 .pg-opt.fixed hr{display:none}.wp-theme-3 .pg-opt .breadcrumb{float:right;margin:0;padding:16px 0;background:none;border-radius:0}.wp-theme-3 .pg-opt .breadcrumb a{color:#59b2e5}@media only screen and (max-width:767px){.wp-theme-3 .pg-opt .pg-nav{float:left;margin-bottom:10px}.wp-theme-3 .pg-opt h2{padding:20px 0 0 0}}.wp-theme-3 .page-header{margin:0;border:0}.wp-theme-3 .page-header p{font-size:16px}.wp-theme-3 .w-box{margin:0 0 15px 0;-webkit-transition:all 0.3s linear;transition:all 0.3s linear;position:relative;overflow:hidden;cursor:default;border:1px solid #e0eded}.wp-theme-3 .w-box:before,.wp-theme-3 .w-box:after{display:table;content:""}.wp-theme-3 .w-box:after{clear:both}.wp-theme-3 .w-box h1{margin:0;padding:10px 15px;font-weight:500;font-size:20px}.wp-theme-3 .lw .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#333}.wp-theme-3 .ld .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#fff}.wp-theme-3 .w-box.inner h2{padding:10px 0}.wp-theme-3 .w-box small{display:block;font-size:12px;margin-top:3px}.wp-theme-3 .w-box p{margin:6px 0;padding:0 15px;padding-bottom:8px}.wp-theme-3 .w-box time{display:block;padding:8px 15px 0 15px}.wp-theme-3 .w-box .w-footer{padding:10px 15px;border-top:1px solid #f1f1f1}.wp-theme-3 .w-box .w-footer:before,.wp-theme-3 .w-box .w-footer:after{display:table;content:""}.wp-theme-3 .w-box .w-footer:after{clear:both}.wp-theme-3 .w-box .w-footer small{font-size:12px}.wp-theme-3 .w-box .w-box-parent{-webkit-transition:all 0.3s linear;transition:all 0.3s linear}.wp-theme-3 .w-box .date-over{padding:10px;background:#fff;position:absolute;top:15px;right:15px;text-align:center;font-weight:normal}.wp-theme-3 .w-box .date-over.small{padding:4px 8px;font-size:12px}.wp-theme-3 .w-box .date-over strong{font-size:12px;display:block;font-weight:normal}.wp-theme-3 .w-box.dark{background:#333}.wp-theme-3 .w-box.dark h2{color:#fff}.wp-theme-3 .w-box.white h2{border-bottom:0;text-align:center}.wp-theme-3 .w-box.white .thmb-img{text-align:center;padding:15px 0}.wp-theme-3 .lw .w-box.white{background:#FFF}.wp-theme-3 .lw .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-3 .ld .w-box.white{background:#202020;border:1px solid #444}.wp-theme-3 .ld .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-3 .w-box.w-box-inverse .thmb-img i{width:100px;height:100px;border-radius:100px;font-size:34px;line-height:100px;text-align:center}.wp-theme-3 .lw .w-box.w-box-inverse .thmb-img i{background:#fcfcfc;color:#59b2e5}.wp-theme-3 .ld .w-box.w-box-inverse .thmb-img i{background:#363636;color:#fff}.wp-theme-3 .w-box.w-box-inverse .thmb-img:hover i{background:#59b2e5;color:#FFF}.wp-theme-3 .c-box{border:1px solid #59b2e5}.wp-theme-3 .c-box .c-box-header{padding:10px 15px;background:#59b2e5;color:#fff;font-size:16px;text-transform:capitalize}.wp-theme-3 .c-box .table{margin:0}.wp-theme-3 .ld .w-section h4,.wp-theme-3 .ld .w-section h3,.wp-theme-3 .ld .w-section h2{color:#fff}.wp-theme-3 .w-section .aside-feature{margin:10px;cursor:default}.wp-theme-3 .w-section .aside-feature .icon-feature{font-size:68px;margin-top:10px;text-align:center;display:block}.wp-theme-3 .w-section .aside-feature:hover .icon-feature,.wp-theme-3 .w-section .aside-feature:hover h4{color:#59b2e5}.wp-theme-3 .w-section .aside-feature .img-feature{margin-top:4px;display:block}.wp-theme-3 .w-section .aside-feature .img-feature img{width:78px}.wp-theme-3 .layer-slider-wrapper{max-height:500px;overflow:hidden;border-bottom:1px solid #e0eded}.wp-theme-3 .layer-slider-wrapper .title{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-3 .layer-slider-wrapper .title.title-base{font-size:36px;line-height:46px;font-weight:500;color:#FFF;background:#e91b23;text-transform:capitalize}.wp-theme-3 .layer-slider-wrapper .title.title-dark{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-3 .layer-slider-wrapper .subtitle{font-size:22px;line-height:30px;color:#59b2e5;text-transform:capitalize}.wp-theme-3 .layer-slider-wrapper .list-item{font-size:18px;line-height:30px;padding-left:30px;color:#59b2e5;text-transform:capitalize}.wp-theme-3 .layer-slider-wrapper .text-standard{font-size:16px;line-height:22px}.wp-theme-3 .box-element{padding:20px}.wp-theme-3 .box-element:nth-child(n+1){margin-top:20px}.wp-theme-3 .box-element h1{margin:10px 0 !important;font-size:20px;line-height:26px;font-weight:400}.wp-theme-3 .box-element.box-element-bordered{background:transparent !important;border:1px solid #59b2e5}.wp-theme-3 .box-element.box-element-outer{padding-left:0;padding-right:0}.wp-theme-3 .pricing-plans .plan-header .popular-tag{background:#333;border-bottom:1px solid #FFF;color:#fff}.wp-theme-3 .carousel-2{position:relative}.wp-theme-3 .carousel-2 .item{padding:36px 0 !important}.wp-theme-3 .carousel-2 .carousel-indicators{bottom:0}.wp-theme-3 .carousel-2 .carousel-indicators li{background-color:#f5f5f5;border:1px solid #ddd;border-radius:10px}.wp-theme-3 .carousel-2 .carousel-indicators .active{background-color:#59b2e5}.wp-theme-3 .carousel-2 .img-thumbnail{margin-top:26px}.wp-theme-3 .carousel-2 h2{font-size:22px}.wp-theme-3 .carousel-2 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:10px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#59b2e5;opacity:1}.wp-theme-3 .carousel-2 .carousel-nav a:hover{background:#59b2e5 !important;color:#fff}.wp-theme-3 .carousel-2 .carousel-nav a.left{right:36px}.wp-theme-3 .carousel-2 .carousel-nav a.right{right:0}.wp-theme-3 .carousel-2 .carousel-control i{position:absolute;top:50%;font-size:22px;margin-top:-11px}.wp-theme-3 .carousel-2 .carousel-control.left i{left:18px}.wp-theme-3 .carousel-2 .carousel-control.right i{right:18px}.wp-theme-3 .carousel-3{position:relative}.wp-theme-3 .carousel-3 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:-50px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#59b2e5;opacity:1}.wp-theme-3 .carousel-3 .carousel-nav a:hover{background:#59b2e5 !important;color:#fff}.wp-theme-3 .carousel-3 .carousel-nav a.left{right:36px}.wp-theme-3 .carousel-3 .carousel-nav a.right{right:0}.wp-theme-3 .carousel-3 .carousel-nav a:hover{background:#FFF}.wp-theme-3 .carousel-testimonials{position:relative;border:1px solid #e0eded}.wp-theme-3 .like-button .button{display:block;text-align:right;padding-top:10px;color:#ddd}.wp-theme-3 .like-button .button i{font-size:20px;color:#ddd}.wp-theme-3 .like-button .button.liked i{color:#59b2e5}.wp-theme-3 .like-button .count{display:block;text-align:right;position:relative;top:-7px}.wp-theme-3 .like-button.inline .button{display:inline-block;padding:0}.wp-theme-3 .like-button.inline .count{display:inline-block;top:-2px}.wp-theme-3 .like-button.inline .count small{font-size:13px}.wp-theme-3 .side-like-box{text-align:center;padding:5px 5px 0 5px;margin-top:10px}.wp-theme-3 .side-like-box .button{text-align:center;padding:0}.wp-theme-3 .side-like-box .count{text-align:center}.wp-theme-3 .side-like-box i{font-size:24px}.wp-theme-3 ul.list-listings{margin:0 0 20px 0;padding:0;list-style:none}.wp-theme-3 ul.list-listings li{margin-bottom:30px;border:1px solid #f3f3f3;overflow:hidden}.wp-theme-3 ul.list-listings li.featured{border-color:#59b2e5}.wp-theme-3 ul.list-listings li:before,.wp-theme-3 ul.list-listings li:after{content:"";display:table}.wp-theme-3 ul.list-listings li:after{clear:both}.wp-theme-3 ul.list-listings .listing-header{clear:both;padding:8px 15px;font-weight:600;text-transform:uppercase}.wp-theme-3 ul.list-listings .listing-image{width:25%;height:150px;float:left;overflow:hidden}.wp-theme-3 ul.list-listings .listing-body{width:50%;height:150px;padding:15px;float:left;background:#fcfcfc;border-right:1px solid #fcfcfc}.wp-theme-3 ul.list-listings .listing-body h3{margin:0;padding:0;font-size:18px;font-weight:500;line-height:25px}.wp-theme-3 ul.list-listings .listing-body h4{font-size:14px;font-weight:normal;line-height:22px}.wp-theme-3 ul.list-listings .listing-actions{width:25%;height:110px;padding-top:40px;float:left;text-align:center}.wp-theme-3 ul.list-listings .listing-actions .btn{margin-top:6px}.wp-theme-3 ul.list-check{list-style:none;margin:0;margin-bottom:15px;padding:0}.wp-theme-3 ul.list-check li{padding:4px 0;margin:0;display:block;width:100%}.wp-theme-3 ul.list-check li i{color:#59b2e5;font-style:normal;margin-right:4px}.wp-theme-3 ul.list-check li span{font-size:14px}.wp-theme-3 ul.categories{list-style:none;margin:0;padding:0 !important;border:1px solid #e0eded;overflow:hidden}.wp-theme-3 ul.categories li{border-bottom:1px solid #e0eded;position:reltive}.wp-theme-3 ul.categories li:last-child{border:0}.wp-theme-3 ul.categories li a{display:block;padding:10px 15px}.wp-theme-3 ul.categories li a:after{font-family:'FontAwesome';content:"\f105";position:relative;top:0;float:right}.wp-theme-3 ul.categories li a:hover{background:#59b2e5;color:#FFF;text-decoration:none}.wp-theme-3 ul.categories li a i{display:inline-block;vertical-align:middle;padding-right:5px;font-style:normal;color:#999;font-size:11px}.wp-theme-3 ul.categories li a:hover i{color:#FFF}.wp-theme-3 .timeline .year{width:100%;background:#333;padding:8px 10px;margin:20px auto 40px !important;font-size:20px}.wp-theme-3 .timeline .year{border-radius:3px}.wp-theme-3 .timeline .event{padding:0;border:1px solid #e0eded;border-radius:0}.wp-theme-3 .timeline .event:nth-child(2n):before{content:"";display:inline-block;position:absolute;right:-6.8% !important;top:20px;width:10px;height:10px;background:#59b2e5;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-3 .timeline .event:nth-child(2n-1):after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #FFF;border-top:12px solid transparent;border-bottom:12px solid transparent}.wp-theme-3 .timeline .event:nth-child(2n-1):before{content:"";display:inline-block;position:absolute;left:-6.5% !important;top:20px;width:10px;height:10px;background:#59b2e5;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-3 .timeline .event-date{margin:0;background:#FFF;border-bottom:1px solid #e0eded;text-align:left;padding:10px 10px;font-weight:500;font-size:14px}.wp-theme-3 .timeline .event:nth-child(2n) .event-date:after{content:"";display:inline-block;position:absolute;right:-12px !important;top:12px;width:0;height:0;border-left:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-3 .timeline .event:nth-child(2n) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;right:-13px;width:0;height:0;border-left:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-3 .timeline .event:nth-child(2n-1) .event-date:after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-3 .timeline .event:nth-child(2n-1) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;left:-13px;width:0;height:0;border-right:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-3 .timeline .event-date small{display:block;font-size:12px;color:#a1a1a1;font-weight:normal}.wp-theme-3 .timeline .event-date i{margin-right:7px}.wp-theme-3 .timeline .event-body{background:#f8f8f8}.wp-theme-3 .timeline .event-footer{margin:0;text-align:left;padding:8px 10px;background:none;border-top:1px solid #e0eded}.wp-theme-3 .timeline .event-footer:after,.wp-theme-3 .timeline .event-footer:before{display:table;content:" "}.wp-theme-3 .timeline .event-footer:after{clear:both}.wp-theme-3 .timeline .event img{margin:0}.wp-theme-3 .timeline p{padding:20px 10px;text-align:left}.wp-theme-3 .timeline iframe{margin:10px 0 0 0}.wp-theme-3 #toTop{display:none;text-decoration:none;position:fixed;bottom:10px;right:10px;overflow:hidden;width:40px;height:40px;border:none;text-indent:100%;background:#555;border-radius:3px}.wp-theme-3 #toTopHover{background:#59b2e5;width:40px;height:40px;display:block;overflow:hidden;float:left;opacity:0;-moz-opacity:0;filter:alpha(opacity=0)}.wp-theme-3 #toTop:active,.wp-theme-3 #toTop:focus{outline:none}.wp-theme-3 #toTop:before{font-family:'FontAwesome';content:"\f106";color:#ffffff;font-size:20px;position:absolute;top:50%;left:50%;width:20px;height:20px;text-align:center;line-height:20px;margin-top:-10px;margin-left:-10px;text-indent:0}.wp-theme-3 .widget.tags-wr{padding-bottom:15px}.wp-theme-3 .tags-list:before,.wp-theme-3 .tags-list:after{display:table;content:""}.wp-theme-3 .tags-list:after{clear:both}.wp-theme-3 .tags-list{list-style:none;padding-left:0;margin:0}.wp-theme-3 .tags-list li{border:1px solid #59b2e5;background:#FFF;padding:5px;float:left;margin-right:5px;margin-bottom:5px;color:#59b2e5;font-size:12px}.wp-theme-3 .tags-list li a{color:#59b2e5;margin-left:4px}.wp-theme-3 .tags-list li:hover{background:#59b2e5;color:#FFF}.wp-theme-3 .tags-list li:hover a{color:#FFF;text-decoration:none}.wp-theme-4 .btn{font-weight:normal;white-space:nowrap;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;border-radius:2px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.wp-theme-4 .btn i{margin-right:4px}.wp-theme-4 .btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:3px}.wp-theme-4 .btn-lg i{font-size:24px;position:relative;top:3px}.wp-theme-4 .btn-xs{padding:4px 10px}.wp-theme-4 .btn-one{background-color:none;border:2px solid #FFF;color:#FFF}.wp-theme-4 .btn-one:hover,.wp-theme-4 .btn-one:focus,.wp-theme-4 .btn-one:active,.wp-theme-4 .btn-one.active,.wp-theme-4 .open .dropdown-toggle.btn-one{color:#8ec449;background-color:#FFF;border-color:#FFF}.wp-theme-4 .btn-one:active,.wp-theme-4 .btn-one.active,.wp-theme-4 .open .dropdown-toggle.btn-one{background-image:none}.wp-theme-4 .btn-two{color:#ffffff;background-color:#8ec449;border:1px solid;border-color:#84ba3f}.wp-theme-4 .btn-two:hover,.wp-theme-4 .btn-two:focus,.wp-theme-4 .btn-two:active,.wp-theme-4 .btn-two.active,.wp-theme-4 .open .dropdown-toggle.btn-two{color:#ffffff;background-color:#7ab035;border-color:#7ab035}.wp-theme-4 .btn-two:active,.wp-theme-4 .btn-two.active,.wp-theme-4 .open .dropdown-toggle.btn-two{background-image:none}.wp-theme-4 .btn-three{color:#ffffff;background-color:#333;border:1px solid;border-color:#292929}.wp-theme-4 .btn-three:hover,.wp-theme-4 .btn-three:focus,.wp-theme-4 .btn-three:active,.wp-theme-4 .btn-three.active,.wp-theme-4 .open .dropdown-toggle.btn-three{color:#ffffff;background-color:#1f1f1f;border-color:#1f1f1f}.wp-theme-4 .btn-three:active,.wp-theme-4 .btn-three.active,.wp-theme-4 .open .dropdown-toggle.btn-three{background-image:none}.wp-theme-4 .btn-four{background-color:none;border:2px solid #8ec449;color:#8ec449}.wp-theme-4 .btn-four:hover,.wp-theme-4 .btn-four:focus,.wp-theme-4 .btn-four:active,.wp-theme-4 .btn-four.active,.wp-theme-4 .open .dropdown-toggle.btn-four{color:#FFF;background-color:#8ec449}.wp-theme-4 .btn-four:active,.wp-theme-4 .btn-four.active,.wp-theme-4 .open .dropdown-toggle.btn-four{background-image:none}.wp-theme-4 h1,.wp-theme-4 h2,.wp-theme-4 h3,.wp-theme-4 h4,.wp-theme-4 h5,.wp-theme-4 h6{font-family:"Roboto",sans-serif !important}.wp-theme-4 p{line-height:22px}.wp-theme-4 a{color:#616161;cursor:pointer}.wp-theme-4 a:hover{color:#8ec449;text-decoration:none;-o-transition:.3s;-ms-transition:.3s;-moz-transition:.3s;-webkit-transition:.3s;transition:.35s}.wp-theme-4 .bg-2{background:#8ec449;color:#FFF}.wp-theme-4 .lw .bg-5{background:#fcfcfc;border-top:1px solid #e0eded;border-bottom:1px solid #e0eded}.wp-theme-4 .ld .bg-5{background:#363636;border-top:1px solid #444;border-bottom:1px solid #444}.wp-theme-4 .lw .bg-3{background:#fff;color:#616161}.wp-theme-4 .ld .bg-3{background:#202020;color:#888}.wp-theme-4 .bg-4{background:#333;color:#FFF}.wp-theme-4 .dark{background:#333;color:#FFF}.wp-theme-4 .red{background:#e91b23;color:#FFF}.wp-theme-4 .orange{background:#f39c12;color:#FFF}.wp-theme-4 .green{background:#f39c12;color:#FFF}.wp-theme-4 .blue{background:#3498db;color:#FFF}.wp-theme-4 .light{background:#fff;color:#616161 !important}.wp-theme-4 .blockquote-1:hover{border-color:#8ec449}.wp-theme-4 .blockquote-1 p{font-size:13px}.wp-theme-4 .section-title{display:inline-block;border-bottom:1px solid #333;margin:0 0 15px 0;padding:0 0 5px 0;font-size:20px;font-weight:500;text-transform:capitalize;position:relative;overflow:hidden}.wp-theme-4 .lw .section-title{color:#333}.wp-theme-4 .ld .section-title{color:#fff}.wp-theme-4 .section-title.white{color:#fff;border-bottom:1px solid #fff}.wp-theme-4 .navbar-wp{margin:0;padding:0;border:0;border-radius:0;z-index:1000}.wp-theme-4 .lw .navbar-wp{background:#fff;border-bottom:1px solid #e0eded}.wp-theme-4 .ld .navbar-wp{background:#181818;border-bottom:1px solid #444}.wp-theme-4 .ld .sticky-wrapper .navbar-wp{background:rgba(24,24,24,0.85);border-bottom:1px solid #444}.wp-theme-4 .navbar-wp .navbar-nav>li>a{padding:28px 16px;margin-right:0;font-size:15px;font-weight:normal}.wp-theme-4 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-4 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-4 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-4 .lw .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#333}.wp-theme-4 .lw .navbar-wp .navbar-nav>li>a:hover,.wp-theme-4 .lw .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#8ec449}.wp-theme-4 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-4 .ld .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#fff}.wp-theme-4 .ld .navbar-wp .navbar-nav>li>a:hover,.wp-theme-4 .ld .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#8ec449}.wp-theme-4 .navbar-wp .navbar-nav>.active>a,.wp-theme-4 .navbar-wp .navbar-nav>.active>a:hover,.wp-theme-4 .navbar-wp .navbar-nav>.active>a:focus{color:#fff !important;background-color:#8ec449;border-radius:0}.wp-theme-4 .navbar-wp .navbar-nav>.disabled>a,.wp-theme-4 .navbar-wp .navbar-nav>.disabled>a:hover,.wp-theme-4 .navbar-wp .navbar-nav>.disabled>a:focus{color:#cccccc;background-color:transparent}.wp-theme-4 .navbar-wp .navbar-nav>.open>a,.wp-theme-4 .navbar-wp .navbar-nav>.open>a:hover,.wp-theme-4 .navbar-wp .navbar-nav>.open>a:focus{color:#FFF !important;background-color:#8ec449}.wp-theme-4 .navbar-wp .navbar-nav>.open>a .caret,.wp-theme-4 .navbar-wp .navbar-nav>.open>a:hover .caret,.wp-theme-4 .navbar-wp .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-4 .navbar-wp .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-4 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle,.wp-theme-4 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-4 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:focus{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none;color:#8ec449}.wp-theme-4 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle,.wp-theme-4 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:hover,.wp-theme-4 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:focus{color:#8ec449 !important;background-color:none}.wp-theme-4 .navbar-wp .navbar-toggle{border-color:#333;margin-top:20px}.wp-theme-4 .navbar-wp .navbar-toggle .icon-bar{background-color:#4c4c4c}.wp-theme-4 .navbar-wp .navbar-toggle .icon-custom{font-size:18px}.wp-theme-4 .navbar-wp .navbar-toggle:hover,.wp-theme-4 .navbar-wp .navbar-toggle:focus{background-color:#8ec449;border-color:#8ec449}.wp-theme-4 .navbar-wp .navbar-toggle:hover .icon-bar,.wp-theme-4 .navbar-wp .navbar-toggle:focus .icon-bar{background-color:#FFF}.wp-theme-4 .navbar-wp .navbar-toggle:hover .icon-custom,.wp-theme-4 .navbar-wp .navbar-toggle:focus .icon-custom{color:#FFF}.wp-theme-4 .navbar-wp .navbar-toggle-aside-menu{padding:8px 10px 2px 10px}.wp-theme-4 .navbar-wp .navbar-collapse,.wp-theme-4 .navbar-wp .navbar-form{border-color:#e7e7e7}.wp-theme-4 .navbar-wp .navbar-nav>.dropdown>a:hover .caret,.wp-theme-4 .navbar-wp .navbar-nav>.dropdown>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-4 .navbar-wp .dropdown-menu{min-width:220px;background:#FFF;border:0;border-top:1px solid #8ec449;border-bottom:3px solid #8ec449;border-radius:0}.wp-theme-4 .navbar-wp .dropdown-menu>li{border-bottom:1px solid #e0eded}.wp-theme-4 .navbar-wp .dropdown-menu>li:last-child{border:0}.wp-theme-4 .navbar-wp .dropdown-menu>li>a{color:#333;padding:8px 15px}.wp-theme-4 .navbar-wp .dropdown-menu>li>a:hover{background:#8ec449;color:#FFF}.wp-theme-4 .navbar-wp .dropdown-menu label.checkbox{color:#333}.wp-theme-4 .navbar-wp .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-4 .navbar-wp .dropdown-menu-user{border:1px solid #e0eded;border-top-color:transparent}.wp-theme-4 .navbar-wp .dropdown-menu-user{background:#fff}.wp-theme-4 .navbar-wp .navbar-right .dropdown-menu-user{background:#fff;border-color:transparent}.wp-theme-4 .navbar-wp .navbar-right .social-link{width:40px;height:40px;line-height:20px;text-align:center;padding:10px;margin:18px 0;border-radius:100%}.wp-theme-4 .navbar-wp .navbar-right .social-link.facebook:hover{background:#43609c;color:#fff}.wp-theme-4 .navbar-wp .navbar-right .social-link.pinterest:hover{background:#cb2027;color:#fff}.wp-theme-4 .navbar-wp .navbar-right .social-link.twitter:hover{background:#62addb;color:#fff}.wp-theme-4 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-4 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-4 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-4 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>.open>a,.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover,.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus{color:#FFF;background-color:#2c2c2c}.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>.open>a .caret,.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover .caret,.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none}.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:focus{background:none;color:#8ec449}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{bottom:100%;right:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-right:-35px}.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{bottom:100%;left:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-left:-35px}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu{min-width:220px;background:#2c2c2c;border:0;border-top:0;border-bottom:0;border-radius:0}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu>li{border-bottom:1px solid #262626}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu>li>a{color:#fff;padding:8px 15px}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu>li>a:hover{background:#8ec449;color:#FFF}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox{color:#fff}.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-4 .dropdown-submenu{position:relative}.wp-theme-4 .dropdown-submenu>.dropdown-menu{top:-5px;left:100%;margin-top:0;margin-left:-1px}.wp-theme-4 .dropdown-submenu:hover>.dropdown-menu{display:block}.wp-theme-4 .dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:3px 0 3px 3px;border-left-color:#ccc;margin-top:5px;margin-right:-6px}.wp-theme-4 .dropdown-submenu:hover>a:after{border-left-color:#fff}.wp-theme-4 .dropdown-submenu.pull-left{float:none}.wp-theme-4 .dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px}.wp-theme-4 .nav>ul{margin:0;padding:0;list-style:none}.wp-theme-4 .nav>ul>li{border-bottom:1px solid #333}.wp-theme-4 .nav>ul>li>a{display:block;padding:10px 15px;font-size:14px;color:#fff}.wp-theme-4 .nav>ul>li>a:hover{text-decoration:none;color:#8ec449;background:#292929}.wp-theme-4 .nav>ul>li>a>i{margin-right:5px}.wp-theme-4 .lw .pg-opt{border-bottom:1px solid #e0eded;background:#fcfcfc}.wp-theme-4 .ld .pg-opt{border-bottom:1px solid #444;background:#111}.wp-theme-4 .pg-opt.fixed{width:100%;position:fixed;top:0px;background:rgba(250,250,250,0.9);border-bottom:1px solid #e0eded;z-index:900}.wp-theme-4 .pg-opt h2{margin:0;padding:14px 0;font-size:22px;line-height:100%}.wp-theme-4 .pg-opt.fixed h2{margin-bottom:15px}.wp-theme-4 .pg-opt hr{margin:0;border-top-color:#dde1e6;-webkit-box-shadow:0 1px 0 #fbfbfc;-moz-box-shadow:0 1px 0 #fbfbfc;box-shadow:0 1px 0 #fbfbfc}.wp-theme-4 .pg-opt.fixed hr{display:none}.wp-theme-4 .pg-opt .breadcrumb{float:right;margin:0;padding:16px 0;background:none;border-radius:0}.wp-theme-4 .pg-opt .breadcrumb a{color:#8ec449}@media only screen and (max-width:767px){.wp-theme-4 .pg-opt .pg-nav{float:left;margin-bottom:10px}.wp-theme-4 .pg-opt h2{padding:20px 0 0 0}}.wp-theme-4 .page-header{margin:0;border:0}.wp-theme-4 .page-header p{font-size:16px}.wp-theme-4 .w-box{margin:0 0 15px 0;-webkit-transition:all 0.3s linear;transition:all 0.3s linear;position:relative;overflow:hidden;cursor:default;border:1px solid #e0eded}.wp-theme-4 .w-box:before,.wp-theme-4 .w-box:after{display:table;content:""}.wp-theme-4 .w-box:after{clear:both}.wp-theme-4 .w-box h1{margin:0;padding:10px 15px;font-weight:500;font-size:20px}.wp-theme-4 .lw .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#333}.wp-theme-4 .ld .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#fff}.wp-theme-4 .w-box.inner h2{padding:10px 0}.wp-theme-4 .w-box small{display:block;font-size:12px;margin-top:3px}.wp-theme-4 .w-box p{margin:6px 0;padding:0 15px;padding-bottom:8px}.wp-theme-4 .w-box time{display:block;padding:8px 15px 0 15px}.wp-theme-4 .w-box .w-footer{padding:10px 15px;border-top:1px solid #f1f1f1}.wp-theme-4 .w-box .w-footer:before,.wp-theme-4 .w-box .w-footer:after{display:table;content:""}.wp-theme-4 .w-box .w-footer:after{clear:both}.wp-theme-4 .w-box .w-footer small{font-size:12px}.wp-theme-4 .w-box .w-box-parent{-webkit-transition:all 0.3s linear;transition:all 0.3s linear}.wp-theme-4 .w-box .date-over{padding:10px;background:#fff;position:absolute;top:15px;right:15px;text-align:center;font-weight:normal}.wp-theme-4 .w-box .date-over.small{padding:4px 8px;font-size:12px}.wp-theme-4 .w-box .date-over strong{font-size:12px;display:block;font-weight:normal}.wp-theme-4 .w-box.dark{background:#333}.wp-theme-4 .w-box.dark h2{color:#fff}.wp-theme-4 .w-box.white h2{border-bottom:0;text-align:center}.wp-theme-4 .w-box.white .thmb-img{text-align:center;padding:15px 0}.wp-theme-4 .lw .w-box.white{background:#FFF}.wp-theme-4 .lw .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-4 .ld .w-box.white{background:#202020;border:1px solid #444}.wp-theme-4 .ld .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-4 .w-box.w-box-inverse .thmb-img i{width:100px;height:100px;border-radius:100px;font-size:34px;line-height:100px;text-align:center}.wp-theme-4 .lw .w-box.w-box-inverse .thmb-img i{background:#fcfcfc;color:#8ec449}.wp-theme-4 .ld .w-box.w-box-inverse .thmb-img i{background:#363636;color:#fff}.wp-theme-4 .w-box.w-box-inverse .thmb-img:hover i{background:#8ec449;color:#FFF}.wp-theme-4 .c-box{border:1px solid #8ec449}.wp-theme-4 .c-box .c-box-header{padding:10px 15px;background:#8ec449;color:#fff;font-size:16px;text-transform:capitalize}.wp-theme-4 .c-box .table{margin:0}.wp-theme-4 .ld .w-section h4,.wp-theme-4 .ld .w-section h3,.wp-theme-4 .ld .w-section h2{color:#fff}.wp-theme-4 .w-section .aside-feature{margin:10px;cursor:default}.wp-theme-4 .w-section .aside-feature .icon-feature{font-size:68px;margin-top:10px;text-align:center;display:block}.wp-theme-4 .w-section .aside-feature:hover .icon-feature,.wp-theme-4 .w-section .aside-feature:hover h4{color:#8ec449}.wp-theme-4 .w-section .aside-feature .img-feature{margin-top:4px;display:block}.wp-theme-4 .w-section .aside-feature .img-feature img{width:78px}.wp-theme-4 .layer-slider-wrapper{max-height:500px;overflow:hidden;border-bottom:1px solid #e0eded}.wp-theme-4 .layer-slider-wrapper .title{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-4 .layer-slider-wrapper .title.title-base{font-size:36px;line-height:46px;font-weight:500;color:#FFF;background:#e91b23;text-transform:capitalize}.wp-theme-4 .layer-slider-wrapper .title.title-dark{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-4 .layer-slider-wrapper .subtitle{font-size:22px;line-height:30px;color:#8ec449;text-transform:capitalize}.wp-theme-4 .layer-slider-wrapper .list-item{font-size:18px;line-height:30px;padding-left:30px;color:#8ec449;text-transform:capitalize}.wp-theme-4 .layer-slider-wrapper .text-standard{font-size:16px;line-height:22px}.wp-theme-4 .box-element{padding:20px}.wp-theme-4 .box-element:nth-child(n+1){margin-top:20px}.wp-theme-4 .box-element h1{margin:10px 0 !important;font-size:20px;line-height:26px;font-weight:400}.wp-theme-4 .box-element.box-element-bordered{background:transparent !important;border:1px solid #8ec449}.wp-theme-4 .box-element.box-element-outer{padding-left:0;padding-right:0}.wp-theme-4 .pricing-plans .plan-header .popular-tag{background:#333;border-bottom:1px solid #FFF;color:#fff}.wp-theme-4 .carousel-2{position:relative}.wp-theme-4 .carousel-2 .item{padding:36px 0 !important}.wp-theme-4 .carousel-2 .carousel-indicators{bottom:0}.wp-theme-4 .carousel-2 .carousel-indicators li{background-color:#f5f5f5;border:1px solid #ddd;border-radius:10px}.wp-theme-4 .carousel-2 .carousel-indicators .active{background-color:#8ec449}.wp-theme-4 .carousel-2 .img-thumbnail{margin-top:26px}.wp-theme-4 .carousel-2 h2{font-size:22px}.wp-theme-4 .carousel-2 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:10px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#8ec449;opacity:1}.wp-theme-4 .carousel-2 .carousel-nav a:hover{background:#8ec449 !important;color:#fff}.wp-theme-4 .carousel-2 .carousel-nav a.left{right:36px}.wp-theme-4 .carousel-2 .carousel-nav a.right{right:0}.wp-theme-4 .carousel-2 .carousel-control i{position:absolute;top:50%;font-size:22px;margin-top:-11px}.wp-theme-4 .carousel-2 .carousel-control.left i{left:18px}.wp-theme-4 .carousel-2 .carousel-control.right i{right:18px}.wp-theme-4 .carousel-3{position:relative}.wp-theme-4 .carousel-3 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:-50px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#8ec449;opacity:1}.wp-theme-4 .carousel-3 .carousel-nav a:hover{background:#8ec449 !important;color:#fff}.wp-theme-4 .carousel-3 .carousel-nav a.left{right:36px}.wp-theme-4 .carousel-3 .carousel-nav a.right{right:0}.wp-theme-4 .carousel-3 .carousel-nav a:hover{background:#FFF}.wp-theme-4 .carousel-testimonials{position:relative;border:1px solid #e0eded}.wp-theme-4 .like-button .button{display:block;text-align:right;padding-top:10px;color:#ddd}.wp-theme-4 .like-button .button i{font-size:20px;color:#ddd}.wp-theme-4 .like-button .button.liked i{color:#8ec449}.wp-theme-4 .like-button .count{display:block;text-align:right;position:relative;top:-7px}.wp-theme-4 .like-button.inline .button{display:inline-block;padding:0}.wp-theme-4 .like-button.inline .count{display:inline-block;top:-2px}.wp-theme-4 .like-button.inline .count small{font-size:13px}.wp-theme-4 .side-like-box{text-align:center;padding:5px 5px 0 5px;margin-top:10px}.wp-theme-4 .side-like-box .button{text-align:center;padding:0}.wp-theme-4 .side-like-box .count{text-align:center}.wp-theme-4 .side-like-box i{font-size:24px}.wp-theme-4 ul.list-listings{margin:0 0 20px 0;padding:0;list-style:none}.wp-theme-4 ul.list-listings li{margin-bottom:30px;border:1px solid #f3f3f3;overflow:hidden}.wp-theme-4 ul.list-listings li.featured{border-color:#8ec449}.wp-theme-4 ul.list-listings li:before,.wp-theme-4 ul.list-listings li:after{content:"";display:table}.wp-theme-4 ul.list-listings li:after{clear:both}.wp-theme-4 ul.list-listings .listing-header{clear:both;padding:8px 15px;font-weight:600;text-transform:uppercase}.wp-theme-4 ul.list-listings .listing-image{width:25%;height:150px;float:left;overflow:hidden}.wp-theme-4 ul.list-listings .listing-body{width:50%;height:150px;padding:15px;float:left;background:#fcfcfc;border-right:1px solid #fcfcfc}.wp-theme-4 ul.list-listings .listing-body h3{margin:0;padding:0;font-size:18px;font-weight:500;line-height:25px}.wp-theme-4 ul.list-listings .listing-body h4{font-size:14px;font-weight:normal;line-height:22px}.wp-theme-4 ul.list-listings .listing-actions{width:25%;height:110px;padding-top:40px;float:left;text-align:center}.wp-theme-4 ul.list-listings .listing-actions .btn{margin-top:6px}.wp-theme-4 ul.list-check{list-style:none;margin:0;margin-bottom:15px;padding:0}.wp-theme-4 ul.list-check li{padding:4px 0;margin:0;display:block;width:100%}.wp-theme-4 ul.list-check li i{color:#8ec449;font-style:normal;margin-right:4px}.wp-theme-4 ul.list-check li span{font-size:14px}.wp-theme-4 ul.categories{list-style:none;margin:0;padding:0 !important;border:1px solid #e0eded;overflow:hidden}.wp-theme-4 ul.categories li{border-bottom:1px solid #e0eded;position:reltive}.wp-theme-4 ul.categories li:last-child{border:0}.wp-theme-4 ul.categories li a{display:block;padding:10px 15px}.wp-theme-4 ul.categories li a:after{font-family:'FontAwesome';content:"\f105";position:relative;top:0;float:right}.wp-theme-4 ul.categories li a:hover{background:#8ec449;color:#FFF;text-decoration:none}.wp-theme-4 ul.categories li a i{display:inline-block;vertical-align:middle;padding-right:5px;font-style:normal;color:#999;font-size:11px}.wp-theme-4 ul.categories li a:hover i{color:#FFF}.wp-theme-4 .timeline .year{width:100%;background:#333;padding:8px 10px;margin:20px auto 40px !important;font-size:20px}.wp-theme-4 .timeline .year{border-radius:3px}.wp-theme-4 .timeline .event{padding:0;border:1px solid #e0eded;border-radius:0}.wp-theme-4 .timeline .event:nth-child(2n):before{content:"";display:inline-block;position:absolute;right:-6.8% !important;top:20px;width:10px;height:10px;background:#8ec449;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-4 .timeline .event:nth-child(2n-1):after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #FFF;border-top:12px solid transparent;border-bottom:12px solid transparent}.wp-theme-4 .timeline .event:nth-child(2n-1):before{content:"";display:inline-block;position:absolute;left:-6.5% !important;top:20px;width:10px;height:10px;background:#8ec449;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-4 .timeline .event-date{margin:0;background:#FFF;border-bottom:1px solid #e0eded;text-align:left;padding:10px 10px;font-weight:500;font-size:14px}.wp-theme-4 .timeline .event:nth-child(2n) .event-date:after{content:"";display:inline-block;position:absolute;right:-12px !important;top:12px;width:0;height:0;border-left:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-4 .timeline .event:nth-child(2n) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;right:-13px;width:0;height:0;border-left:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-4 .timeline .event:nth-child(2n-1) .event-date:after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-4 .timeline .event:nth-child(2n-1) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;left:-13px;width:0;height:0;border-right:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-4 .timeline .event-date small{display:block;font-size:12px;color:#a1a1a1;font-weight:normal}.wp-theme-4 .timeline .event-date i{margin-right:7px}.wp-theme-4 .timeline .event-body{background:#f8f8f8}.wp-theme-4 .timeline .event-footer{margin:0;text-align:left;padding:8px 10px;background:none;border-top:1px solid #e0eded}.wp-theme-4 .timeline .event-footer:after,.wp-theme-4 .timeline .event-footer:before{display:table;content:" "}.wp-theme-4 .timeline .event-footer:after{clear:both}.wp-theme-4 .timeline .event img{margin:0}.wp-theme-4 .timeline p{padding:20px 10px;text-align:left}.wp-theme-4 .timeline iframe{margin:10px 0 0 0}.wp-theme-4 #toTop{display:none;text-decoration:none;position:fixed;bottom:10px;right:10px;overflow:hidden;width:40px;height:40px;border:none;text-indent:100%;background:#555;border-radius:3px}.wp-theme-4 #toTopHover{background:#8ec449;width:40px;height:40px;display:block;overflow:hidden;float:left;opacity:0;-moz-opacity:0;filter:alpha(opacity=0)}.wp-theme-4 #toTop:active,.wp-theme-4 #toTop:focus{outline:none}.wp-theme-4 #toTop:before{font-family:'FontAwesome';content:"\f106";color:#ffffff;font-size:20px;position:absolute;top:50%;left:50%;width:20px;height:20px;text-align:center;line-height:20px;margin-top:-10px;margin-left:-10px;text-indent:0}.wp-theme-4 .widget.tags-wr{padding-bottom:15px}.wp-theme-4 .tags-list:before,.wp-theme-4 .tags-list:after{display:table;content:""}.wp-theme-4 .tags-list:after{clear:both}.wp-theme-4 .tags-list{list-style:none;padding-left:0;margin:0}.wp-theme-4 .tags-list li{border:1px solid #8ec449;background:#FFF;padding:5px;float:left;margin-right:5px;margin-bottom:5px;color:#8ec449;font-size:12px}.wp-theme-4 .tags-list li a{color:#8ec449;margin-left:4px}.wp-theme-4 .tags-list li:hover{background:#8ec449;color:#FFF}.wp-theme-4 .tags-list li:hover a{color:#FFF;text-decoration:none}.wp-theme-5 .btn{font-weight:normal;white-space:nowrap;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;border-radius:2px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.wp-theme-5 .btn i{margin-right:4px}.wp-theme-5 .btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:3px}.wp-theme-5 .btn-lg i{font-size:24px;position:relative;top:3px}.wp-theme-5 .btn-xs{padding:4px 10px}.wp-theme-5 .btn-one{background-color:none;border:2px solid #FFF;color:#FFF}.wp-theme-5 .btn-one:hover,.wp-theme-5 .btn-one:focus,.wp-theme-5 .btn-one:active,.wp-theme-5 .btn-one.active,.wp-theme-5 .open .dropdown-toggle.btn-one{color:#f1c40f;background-color:#FFF;border-color:#FFF}.wp-theme-5 .btn-one:active,.wp-theme-5 .btn-one.active,.wp-theme-5 .open .dropdown-toggle.btn-one{background-image:none}.wp-theme-5 .btn-two{color:#ffffff;background-color:#f1c40f;border:1px solid;border-color:#e7ba05}.wp-theme-5 .btn-two:hover,.wp-theme-5 .btn-two:focus,.wp-theme-5 .btn-two:active,.wp-theme-5 .btn-two.active,.wp-theme-5 .open .dropdown-toggle.btn-two{color:#ffffff;background-color:#ddb000;border-color:#ddb000}.wp-theme-5 .btn-two:active,.wp-theme-5 .btn-two.active,.wp-theme-5 .open .dropdown-toggle.btn-two{background-image:none}.wp-theme-5 .btn-three{color:#ffffff;background-color:#333;border:1px solid;border-color:#292929}.wp-theme-5 .btn-three:hover,.wp-theme-5 .btn-three:focus,.wp-theme-5 .btn-three:active,.wp-theme-5 .btn-three.active,.wp-theme-5 .open .dropdown-toggle.btn-three{color:#ffffff;background-color:#1f1f1f;border-color:#1f1f1f}.wp-theme-5 .btn-three:active,.wp-theme-5 .btn-three.active,.wp-theme-5 .open .dropdown-toggle.btn-three{background-image:none}.wp-theme-5 .btn-four{background-color:none;border:2px solid #f1c40f;color:#f1c40f}.wp-theme-5 .btn-four:hover,.wp-theme-5 .btn-four:focus,.wp-theme-5 .btn-four:active,.wp-theme-5 .btn-four.active,.wp-theme-5 .open .dropdown-toggle.btn-four{color:#FFF;background-color:#f1c40f}.wp-theme-5 .btn-four:active,.wp-theme-5 .btn-four.active,.wp-theme-5 .open .dropdown-toggle.btn-four{background-image:none}.wp-theme-5 h1,.wp-theme-5 h2,.wp-theme-5 h3,.wp-theme-5 h4,.wp-theme-5 h5,.wp-theme-5 h6{font-family:"Roboto",sans-serif !important}.wp-theme-5 p{line-height:22px}.wp-theme-5 a{color:#616161;cursor:pointer}.wp-theme-5 a:hover{color:#f1c40f;text-decoration:none;-o-transition:.3s;-ms-transition:.3s;-moz-transition:.3s;-webkit-transition:.3s;transition:.35s}.wp-theme-5 .bg-2{background:#f1c40f;color:#FFF}.wp-theme-5 .lw .bg-5{background:#fcfcfc;border-top:1px solid #e0eded;border-bottom:1px solid #e0eded}.wp-theme-5 .ld .bg-5{background:#363636;border-top:1px solid #444;border-bottom:1px solid #444}.wp-theme-5 .lw .bg-3{background:#fff;color:#616161}.wp-theme-5 .ld .bg-3{background:#202020;color:#888}.wp-theme-5 .bg-4{background:#333;color:#FFF}.wp-theme-5 .dark{background:#333;color:#FFF}.wp-theme-5 .red{background:#e91b23;color:#FFF}.wp-theme-5 .orange{background:#f39c12;color:#FFF}.wp-theme-5 .green{background:#f39c12;color:#FFF}.wp-theme-5 .blue{background:#3498db;color:#FFF}.wp-theme-5 .light{background:#fff;color:#616161 !important}.wp-theme-5 .blockquote-1:hover{border-color:#f1c40f}.wp-theme-5 .blockquote-1 p{font-size:13px}.wp-theme-5 .section-title{display:inline-block;border-bottom:1px solid #333;margin:0 0 15px 0;padding:0 0 5px 0;font-size:20px;font-weight:500;text-transform:capitalize;position:relative;overflow:hidden}.wp-theme-5 .lw .section-title{color:#333}.wp-theme-5 .ld .section-title{color:#fff}.wp-theme-5 .section-title.white{color:#fff;border-bottom:1px solid #fff}.wp-theme-5 .navbar-wp{margin:0;padding:0;border:0;border-radius:0;z-index:1000}.wp-theme-5 .lw .navbar-wp{background:#fff;border-bottom:1px solid #e0eded}.wp-theme-5 .ld .navbar-wp{background:#181818;border-bottom:1px solid #444}.wp-theme-5 .ld .sticky-wrapper .navbar-wp{background:rgba(24,24,24,0.85);border-bottom:1px solid #444}.wp-theme-5 .navbar-wp .navbar-nav>li>a{padding:28px 16px;margin-right:0;font-size:15px;font-weight:normal}.wp-theme-5 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-5 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-5 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-5 .lw .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#333}.wp-theme-5 .lw .navbar-wp .navbar-nav>li>a:hover,.wp-theme-5 .lw .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#f1c40f}.wp-theme-5 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-5 .ld .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#fff}.wp-theme-5 .ld .navbar-wp .navbar-nav>li>a:hover,.wp-theme-5 .ld .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#f1c40f}.wp-theme-5 .navbar-wp .navbar-nav>.active>a,.wp-theme-5 .navbar-wp .navbar-nav>.active>a:hover,.wp-theme-5 .navbar-wp .navbar-nav>.active>a:focus{color:#fff !important;background-color:#f1c40f;border-radius:0}.wp-theme-5 .navbar-wp .navbar-nav>.disabled>a,.wp-theme-5 .navbar-wp .navbar-nav>.disabled>a:hover,.wp-theme-5 .navbar-wp .navbar-nav>.disabled>a:focus{color:#cccccc;background-color:transparent}.wp-theme-5 .navbar-wp .navbar-nav>.open>a,.wp-theme-5 .navbar-wp .navbar-nav>.open>a:hover,.wp-theme-5 .navbar-wp .navbar-nav>.open>a:focus{color:#FFF !important;background-color:#f1c40f}.wp-theme-5 .navbar-wp .navbar-nav>.open>a .caret,.wp-theme-5 .navbar-wp .navbar-nav>.open>a:hover .caret,.wp-theme-5 .navbar-wp .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-5 .navbar-wp .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-5 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle,.wp-theme-5 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-5 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:focus{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none;color:#f1c40f}.wp-theme-5 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle,.wp-theme-5 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:hover,.wp-theme-5 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:focus{color:#f1c40f !important;background-color:none}.wp-theme-5 .navbar-wp .navbar-toggle{border-color:#333;margin-top:20px}.wp-theme-5 .navbar-wp .navbar-toggle .icon-bar{background-color:#4c4c4c}.wp-theme-5 .navbar-wp .navbar-toggle .icon-custom{font-size:18px}.wp-theme-5 .navbar-wp .navbar-toggle:hover,.wp-theme-5 .navbar-wp .navbar-toggle:focus{background-color:#f1c40f;border-color:#f1c40f}.wp-theme-5 .navbar-wp .navbar-toggle:hover .icon-bar,.wp-theme-5 .navbar-wp .navbar-toggle:focus .icon-bar{background-color:#FFF}.wp-theme-5 .navbar-wp .navbar-toggle:hover .icon-custom,.wp-theme-5 .navbar-wp .navbar-toggle:focus .icon-custom{color:#FFF}.wp-theme-5 .navbar-wp .navbar-toggle-aside-menu{padding:8px 10px 2px 10px}.wp-theme-5 .navbar-wp .navbar-collapse,.wp-theme-5 .navbar-wp .navbar-form{border-color:#e7e7e7}.wp-theme-5 .navbar-wp .navbar-nav>.dropdown>a:hover .caret,.wp-theme-5 .navbar-wp .navbar-nav>.dropdown>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-5 .navbar-wp .dropdown-menu{min-width:220px;background:#FFF;border:0;border-top:1px solid #f1c40f;border-bottom:3px solid #f1c40f;border-radius:0}.wp-theme-5 .navbar-wp .dropdown-menu>li{border-bottom:1px solid #e0eded}.wp-theme-5 .navbar-wp .dropdown-menu>li:last-child{border:0}.wp-theme-5 .navbar-wp .dropdown-menu>li>a{color:#333;padding:8px 15px}.wp-theme-5 .navbar-wp .dropdown-menu>li>a:hover{background:#f1c40f;color:#FFF}.wp-theme-5 .navbar-wp .dropdown-menu label.checkbox{color:#333}.wp-theme-5 .navbar-wp .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-5 .navbar-wp .dropdown-menu-user{border:1px solid #e0eded;border-top-color:transparent}.wp-theme-5 .navbar-wp .dropdown-menu-user{background:#fff}.wp-theme-5 .navbar-wp .navbar-right .dropdown-menu-user{background:#fff;border-color:transparent}.wp-theme-5 .navbar-wp .navbar-right .social-link{width:40px;height:40px;line-height:20px;text-align:center;padding:10px;margin:18px 0;border-radius:100%}.wp-theme-5 .navbar-wp .navbar-right .social-link.facebook:hover{background:#43609c;color:#fff}.wp-theme-5 .navbar-wp .navbar-right .social-link.pinterest:hover{background:#cb2027;color:#fff}.wp-theme-5 .navbar-wp .navbar-right .social-link.twitter:hover{background:#62addb;color:#fff}.wp-theme-5 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-5 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-5 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-5 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>.open>a,.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover,.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus{color:#FFF;background-color:#2c2c2c}.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>.open>a .caret,.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover .caret,.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none}.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:focus{background:none;color:#f1c40f}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{bottom:100%;right:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-right:-35px}.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{bottom:100%;left:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-left:-35px}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu{min-width:220px;background:#2c2c2c;border:0;border-top:0;border-bottom:0;border-radius:0}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu>li{border-bottom:1px solid #262626}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu>li>a{color:#fff;padding:8px 15px}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu>li>a:hover{background:#f1c40f;color:#FFF}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox{color:#fff}.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-5 .dropdown-submenu{position:relative}.wp-theme-5 .dropdown-submenu>.dropdown-menu{top:-5px;left:100%;margin-top:0;margin-left:-1px}.wp-theme-5 .dropdown-submenu:hover>.dropdown-menu{display:block}.wp-theme-5 .dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:3px 0 3px 3px;border-left-color:#ccc;margin-top:5px;margin-right:-6px}.wp-theme-5 .dropdown-submenu:hover>a:after{border-left-color:#fff}.wp-theme-5 .dropdown-submenu.pull-left{float:none}.wp-theme-5 .dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px}.wp-theme-5 .nav>ul{margin:0;padding:0;list-style:none}.wp-theme-5 .nav>ul>li{border-bottom:1px solid #333}.wp-theme-5 .nav>ul>li>a{display:block;padding:10px 15px;font-size:14px;color:#fff}.wp-theme-5 .nav>ul>li>a:hover{text-decoration:none;color:#f1c40f;background:#292929}.wp-theme-5 .nav>ul>li>a>i{margin-right:5px}.wp-theme-5 .lw .pg-opt{border-bottom:1px solid #e0eded;background:#fcfcfc}.wp-theme-5 .ld .pg-opt{border-bottom:1px solid #444;background:#111}.wp-theme-5 .pg-opt.fixed{width:100%;position:fixed;top:0px;background:rgba(250,250,250,0.9);border-bottom:1px solid #e0eded;z-index:900}.wp-theme-5 .pg-opt h2{margin:0;padding:14px 0;font-size:22px;line-height:100%}.wp-theme-5 .pg-opt.fixed h2{margin-bottom:15px}.wp-theme-5 .pg-opt hr{margin:0;border-top-color:#dde1e6;-webkit-box-shadow:0 1px 0 #fbfbfc;-moz-box-shadow:0 1px 0 #fbfbfc;box-shadow:0 1px 0 #fbfbfc}.wp-theme-5 .pg-opt.fixed hr{display:none}.wp-theme-5 .pg-opt .breadcrumb{float:right;margin:0;padding:16px 0;background:none;border-radius:0}.wp-theme-5 .pg-opt .breadcrumb a{color:#f1c40f}@media only screen and (max-width:767px){.wp-theme-5 .pg-opt .pg-nav{float:left;margin-bottom:10px}.wp-theme-5 .pg-opt h2{padding:20px 0 0 0}}.wp-theme-5 .page-header{margin:0;border:0}.wp-theme-5 .page-header p{font-size:16px}.wp-theme-5 .w-box{margin:0 0 15px 0;-webkit-transition:all 0.3s linear;transition:all 0.3s linear;position:relative;overflow:hidden;cursor:default;border:1px solid #e0eded}.wp-theme-5 .w-box:before,.wp-theme-5 .w-box:after{display:table;content:""}.wp-theme-5 .w-box:after{clear:both}.wp-theme-5 .w-box h1{margin:0;padding:10px 15px;font-weight:500;font-size:20px}.wp-theme-5 .lw .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#333}.wp-theme-5 .ld .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#fff}.wp-theme-5 .w-box.inner h2{padding:10px 0}.wp-theme-5 .w-box small{display:block;font-size:12px;margin-top:3px}.wp-theme-5 .w-box p{margin:6px 0;padding:0 15px;padding-bottom:8px}.wp-theme-5 .w-box time{display:block;padding:8px 15px 0 15px}.wp-theme-5 .w-box .w-footer{padding:10px 15px;border-top:1px solid #f1f1f1}.wp-theme-5 .w-box .w-footer:before,.wp-theme-5 .w-box .w-footer:after{display:table;content:""}.wp-theme-5 .w-box .w-footer:after{clear:both}.wp-theme-5 .w-box .w-footer small{font-size:12px}.wp-theme-5 .w-box .w-box-parent{-webkit-transition:all 0.3s linear;transition:all 0.3s linear}.wp-theme-5 .w-box .date-over{padding:10px;background:#fff;position:absolute;top:15px;right:15px;text-align:center;font-weight:normal}.wp-theme-5 .w-box .date-over.small{padding:4px 8px;font-size:12px}.wp-theme-5 .w-box .date-over strong{font-size:12px;display:block;font-weight:normal}.wp-theme-5 .w-box.dark{background:#333}.wp-theme-5 .w-box.dark h2{color:#fff}.wp-theme-5 .w-box.white h2{border-bottom:0;text-align:center}.wp-theme-5 .w-box.white .thmb-img{text-align:center;padding:15px 0}.wp-theme-5 .lw .w-box.white{background:#FFF}.wp-theme-5 .lw .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-5 .ld .w-box.white{background:#202020;border:1px solid #444}.wp-theme-5 .ld .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-5 .w-box.w-box-inverse .thmb-img i{width:100px;height:100px;border-radius:100px;font-size:34px;line-height:100px;text-align:center}.wp-theme-5 .lw .w-box.w-box-inverse .thmb-img i{background:#fcfcfc;color:#f1c40f}.wp-theme-5 .ld .w-box.w-box-inverse .thmb-img i{background:#363636;color:#fff}.wp-theme-5 .w-box.w-box-inverse .thmb-img:hover i{background:#f1c40f;color:#FFF}.wp-theme-5 .c-box{border:1px solid #f1c40f}.wp-theme-5 .c-box .c-box-header{padding:10px 15px;background:#f1c40f;color:#fff;font-size:16px;text-transform:capitalize}.wp-theme-5 .c-box .table{margin:0}.wp-theme-5 .ld .w-section h4,.wp-theme-5 .ld .w-section h3,.wp-theme-5 .ld .w-section h2{color:#fff}.wp-theme-5 .w-section .aside-feature{margin:10px;cursor:default}.wp-theme-5 .w-section .aside-feature .icon-feature{font-size:68px;margin-top:10px;text-align:center;display:block}.wp-theme-5 .w-section .aside-feature:hover .icon-feature,.wp-theme-5 .w-section .aside-feature:hover h4{color:#f1c40f}.wp-theme-5 .w-section .aside-feature .img-feature{margin-top:4px;display:block}.wp-theme-5 .w-section .aside-feature .img-feature img{width:78px}.wp-theme-5 .layer-slider-wrapper{max-height:500px;overflow:hidden;border-bottom:1px solid #e0eded}.wp-theme-5 .layer-slider-wrapper .title{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-5 .layer-slider-wrapper .title.title-base{font-size:36px;line-height:46px;font-weight:500;color:#FFF;background:#e91b23;text-transform:capitalize}.wp-theme-5 .layer-slider-wrapper .title.title-dark{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-5 .layer-slider-wrapper .subtitle{font-size:22px;line-height:30px;color:#f1c40f;text-transform:capitalize}.wp-theme-5 .layer-slider-wrapper .list-item{font-size:18px;line-height:30px;padding-left:30px;color:#f1c40f;text-transform:capitalize}.wp-theme-5 .layer-slider-wrapper .text-standard{font-size:16px;line-height:22px}.wp-theme-5 .box-element{padding:20px}.wp-theme-5 .box-element:nth-child(n+1){margin-top:20px}.wp-theme-5 .box-element h1{margin:10px 0 !important;font-size:20px;line-height:26px;font-weight:400}.wp-theme-5 .box-element.box-element-bordered{background:transparent !important;border:1px solid #f1c40f}.wp-theme-5 .box-element.box-element-outer{padding-left:0;padding-right:0}.wp-theme-5 .pricing-plans .plan-header .popular-tag{background:#333;border-bottom:1px solid #FFF;color:#fff}.wp-theme-5 .carousel-2{position:relative}.wp-theme-5 .carousel-2 .item{padding:36px 0 !important}.wp-theme-5 .carousel-2 .carousel-indicators{bottom:0}.wp-theme-5 .carousel-2 .carousel-indicators li{background-color:#f5f5f5;border:1px solid #ddd;border-radius:10px}.wp-theme-5 .carousel-2 .carousel-indicators .active{background-color:#f1c40f}.wp-theme-5 .carousel-2 .img-thumbnail{margin-top:26px}.wp-theme-5 .carousel-2 h2{font-size:22px}.wp-theme-5 .carousel-2 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:10px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#f1c40f;opacity:1}.wp-theme-5 .carousel-2 .carousel-nav a:hover{background:#f1c40f !important;color:#fff}.wp-theme-5 .carousel-2 .carousel-nav a.left{right:36px}.wp-theme-5 .carousel-2 .carousel-nav a.right{right:0}.wp-theme-5 .carousel-2 .carousel-control i{position:absolute;top:50%;font-size:22px;margin-top:-11px}.wp-theme-5 .carousel-2 .carousel-control.left i{left:18px}.wp-theme-5 .carousel-2 .carousel-control.right i{right:18px}.wp-theme-5 .carousel-3{position:relative}.wp-theme-5 .carousel-3 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:-50px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#f1c40f;opacity:1}.wp-theme-5 .carousel-3 .carousel-nav a:hover{background:#f1c40f !important;color:#fff}.wp-theme-5 .carousel-3 .carousel-nav a.left{right:36px}.wp-theme-5 .carousel-3 .carousel-nav a.right{right:0}.wp-theme-5 .carousel-3 .carousel-nav a:hover{background:#FFF}.wp-theme-5 .carousel-testimonials{position:relative;border:1px solid #e0eded}.wp-theme-5 .like-button .button{display:block;text-align:right;padding-top:10px;color:#ddd}.wp-theme-5 .like-button .button i{font-size:20px;color:#ddd}.wp-theme-5 .like-button .button.liked i{color:#f1c40f}.wp-theme-5 .like-button .count{display:block;text-align:right;position:relative;top:-7px}.wp-theme-5 .like-button.inline .button{display:inline-block;padding:0}.wp-theme-5 .like-button.inline .count{display:inline-block;top:-2px}.wp-theme-5 .like-button.inline .count small{font-size:13px}.wp-theme-5 .side-like-box{text-align:center;padding:5px 5px 0 5px;margin-top:10px}.wp-theme-5 .side-like-box .button{text-align:center;padding:0}.wp-theme-5 .side-like-box .count{text-align:center}.wp-theme-5 .side-like-box i{font-size:24px}.wp-theme-5 ul.list-listings{margin:0 0 20px 0;padding:0;list-style:none}.wp-theme-5 ul.list-listings li{margin-bottom:30px;border:1px solid #f3f3f3;overflow:hidden}.wp-theme-5 ul.list-listings li.featured{border-color:#f1c40f}.wp-theme-5 ul.list-listings li:before,.wp-theme-5 ul.list-listings li:after{content:"";display:table}.wp-theme-5 ul.list-listings li:after{clear:both}.wp-theme-5 ul.list-listings .listing-header{clear:both;padding:8px 15px;font-weight:600;text-transform:uppercase}.wp-theme-5 ul.list-listings .listing-image{width:25%;height:150px;float:left;overflow:hidden}.wp-theme-5 ul.list-listings .listing-body{width:50%;height:150px;padding:15px;float:left;background:#fcfcfc;border-right:1px solid #fcfcfc}.wp-theme-5 ul.list-listings .listing-body h3{margin:0;padding:0;font-size:18px;font-weight:500;line-height:25px}.wp-theme-5 ul.list-listings .listing-body h4{font-size:14px;font-weight:normal;line-height:22px}.wp-theme-5 ul.list-listings .listing-actions{width:25%;height:110px;padding-top:40px;float:left;text-align:center}.wp-theme-5 ul.list-listings .listing-actions .btn{margin-top:6px}.wp-theme-5 ul.list-check{list-style:none;margin:0;margin-bottom:15px;padding:0}.wp-theme-5 ul.list-check li{padding:4px 0;margin:0;display:block;width:100%}.wp-theme-5 ul.list-check li i{color:#f1c40f;font-style:normal;margin-right:4px}.wp-theme-5 ul.list-check li span{font-size:14px}.wp-theme-5 ul.categories{list-style:none;margin:0;padding:0 !important;border:1px solid #e0eded;overflow:hidden}.wp-theme-5 ul.categories li{border-bottom:1px solid #e0eded;position:reltive}.wp-theme-5 ul.categories li:last-child{border:0}.wp-theme-5 ul.categories li a{display:block;padding:10px 15px}.wp-theme-5 ul.categories li a:after{font-family:'FontAwesome';content:"\f105";position:relative;top:0;float:right}.wp-theme-5 ul.categories li a:hover{background:#f1c40f;color:#FFF;text-decoration:none}.wp-theme-5 ul.categories li a i{display:inline-block;vertical-align:middle;padding-right:5px;font-style:normal;color:#999;font-size:11px}.wp-theme-5 ul.categories li a:hover i{color:#FFF}.wp-theme-5 .timeline .year{width:100%;background:#333;padding:8px 10px;margin:20px auto 40px !important;font-size:20px}.wp-theme-5 .timeline .year{border-radius:3px}.wp-theme-5 .timeline .event{padding:0;border:1px solid #e0eded;border-radius:0}.wp-theme-5 .timeline .event:nth-child(2n):before{content:"";display:inline-block;position:absolute;right:-6.8% !important;top:20px;width:10px;height:10px;background:#f1c40f;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-5 .timeline .event:nth-child(2n-1):after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #FFF;border-top:12px solid transparent;border-bottom:12px solid transparent}.wp-theme-5 .timeline .event:nth-child(2n-1):before{content:"";display:inline-block;position:absolute;left:-6.5% !important;top:20px;width:10px;height:10px;background:#f1c40f;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-5 .timeline .event-date{margin:0;background:#FFF;border-bottom:1px solid #e0eded;text-align:left;padding:10px 10px;font-weight:500;font-size:14px}.wp-theme-5 .timeline .event:nth-child(2n) .event-date:after{content:"";display:inline-block;position:absolute;right:-12px !important;top:12px;width:0;height:0;border-left:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-5 .timeline .event:nth-child(2n) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;right:-13px;width:0;height:0;border-left:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-5 .timeline .event:nth-child(2n-1) .event-date:after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-5 .timeline .event:nth-child(2n-1) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;left:-13px;width:0;height:0;border-right:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-5 .timeline .event-date small{display:block;font-size:12px;color:#a1a1a1;font-weight:normal}.wp-theme-5 .timeline .event-date i{margin-right:7px}.wp-theme-5 .timeline .event-body{background:#f8f8f8}.wp-theme-5 .timeline .event-footer{margin:0;text-align:left;padding:8px 10px;background:none;border-top:1px solid #e0eded}.wp-theme-5 .timeline .event-footer:after,.wp-theme-5 .timeline .event-footer:before{display:table;content:" "}.wp-theme-5 .timeline .event-footer:after{clear:both}.wp-theme-5 .timeline .event img{margin:0}.wp-theme-5 .timeline p{padding:20px 10px;text-align:left}.wp-theme-5 .timeline iframe{margin:10px 0 0 0}.wp-theme-5 #toTop{display:none;text-decoration:none;position:fixed;bottom:10px;right:10px;overflow:hidden;width:40px;height:40px;border:none;text-indent:100%;background:#555;border-radius:3px}.wp-theme-5 #toTopHover{background:#f1c40f;width:40px;height:40px;display:block;overflow:hidden;float:left;opacity:0;-moz-opacity:0;filter:alpha(opacity=0)}.wp-theme-5 #toTop:active,.wp-theme-5 #toTop:focus{outline:none}.wp-theme-5 #toTop:before{font-family:'FontAwesome';content:"\f106";color:#ffffff;font-size:20px;position:absolute;top:50%;left:50%;width:20px;height:20px;text-align:center;line-height:20px;margin-top:-10px;margin-left:-10px;text-indent:0}.wp-theme-5 .widget.tags-wr{padding-bottom:15px}.wp-theme-5 .tags-list:before,.wp-theme-5 .tags-list:after{display:table;content:""}.wp-theme-5 .tags-list:after{clear:both}.wp-theme-5 .tags-list{list-style:none;padding-left:0;margin:0}.wp-theme-5 .tags-list li{border:1px solid #f1c40f;background:#FFF;padding:5px;float:left;margin-right:5px;margin-bottom:5px;color:#f1c40f;font-size:12px}.wp-theme-5 .tags-list li a{color:#f1c40f;margin-left:4px}.wp-theme-5 .tags-list li:hover{background:#f1c40f;color:#FFF}.wp-theme-5 .tags-list li:hover a{color:#FFF;text-decoration:none}.wp-theme-6 .btn{font-weight:normal;white-space:nowrap;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;border-radius:2px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.wp-theme-6 .btn i{margin-right:4px}.wp-theme-6 .btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:3px}.wp-theme-6 .btn-lg i{font-size:24px;position:relative;top:3px}.wp-theme-6 .btn-xs{padding:4px 10px}.wp-theme-6 .btn-one{background-color:none;border:2px solid #FFF;color:#FFF}.wp-theme-6 .btn-one:hover,.wp-theme-6 .btn-one:focus,.wp-theme-6 .btn-one:active,.wp-theme-6 .btn-one.active,.wp-theme-6 .open .dropdown-toggle.btn-one{color:#d35400;background-color:#FFF;border-color:#FFF}.wp-theme-6 .btn-one:active,.wp-theme-6 .btn-one.active,.wp-theme-6 .open .dropdown-toggle.btn-one{background-image:none}.wp-theme-6 .btn-two{color:#ffffff;background-color:#d35400;border:1px solid;border-color:#c94a00}.wp-theme-6 .btn-two:hover,.wp-theme-6 .btn-two:focus,.wp-theme-6 .btn-two:active,.wp-theme-6 .btn-two.active,.wp-theme-6 .open .dropdown-toggle.btn-two{color:#ffffff;background-color:#bf4000;border-color:#bf4000}.wp-theme-6 .btn-two:active,.wp-theme-6 .btn-two.active,.wp-theme-6 .open .dropdown-toggle.btn-two{background-image:none}.wp-theme-6 .btn-three{color:#ffffff;background-color:#333;border:1px solid;border-color:#292929}.wp-theme-6 .btn-three:hover,.wp-theme-6 .btn-three:focus,.wp-theme-6 .btn-three:active,.wp-theme-6 .btn-three.active,.wp-theme-6 .open .dropdown-toggle.btn-three{color:#ffffff;background-color:#1f1f1f;border-color:#1f1f1f}.wp-theme-6 .btn-three:active,.wp-theme-6 .btn-three.active,.wp-theme-6 .open .dropdown-toggle.btn-three{background-image:none}.wp-theme-6 .btn-four{background-color:none;border:2px solid #d35400;color:#d35400}.wp-theme-6 .btn-four:hover,.wp-theme-6 .btn-four:focus,.wp-theme-6 .btn-four:active,.wp-theme-6 .btn-four.active,.wp-theme-6 .open .dropdown-toggle.btn-four{color:#FFF;background-color:#d35400}.wp-theme-6 .btn-four:active,.wp-theme-6 .btn-four.active,.wp-theme-6 .open .dropdown-toggle.btn-four{background-image:none}.wp-theme-6 h1,.wp-theme-6 h2,.wp-theme-6 h3,.wp-theme-6 h4,.wp-theme-6 h5,.wp-theme-6 h6{font-family:"Roboto",sans-serif !important}.wp-theme-6 p{line-height:22px}.wp-theme-6 a{color:#616161;cursor:pointer}.wp-theme-6 a:hover{color:#d35400;text-decoration:none;-o-transition:.3s;-ms-transition:.3s;-moz-transition:.3s;-webkit-transition:.3s;transition:.35s}.wp-theme-6 .bg-2{background:#d35400;color:#FFF}.wp-theme-6 .lw .bg-5{background:#fcfcfc;border-top:1px solid #e0eded;border-bottom:1px solid #e0eded}.wp-theme-6 .ld .bg-5{background:#363636;border-top:1px solid #444;border-bottom:1px solid #444}.wp-theme-6 .lw .bg-3{background:#fff;color:#616161}.wp-theme-6 .ld .bg-3{background:#202020;color:#888}.wp-theme-6 .bg-4{background:#333;color:#FFF}.wp-theme-6 .dark{background:#333;color:#FFF}.wp-theme-6 .red{background:#e91b23;color:#FFF}.wp-theme-6 .orange{background:#f39c12;color:#FFF}.wp-theme-6 .green{background:#f39c12;color:#FFF}.wp-theme-6 .blue{background:#3498db;color:#FFF}.wp-theme-6 .light{background:#fff;color:#616161 !important}.wp-theme-6 .blockquote-1:hover{border-color:#d35400}.wp-theme-6 .blockquote-1 p{font-size:13px}.wp-theme-6 .section-title{display:inline-block;border-bottom:1px solid #333;margin:0 0 15px 0;padding:0 0 5px 0;font-size:20px;font-weight:500;text-transform:capitalize;position:relative;overflow:hidden}.wp-theme-6 .lw .section-title{color:#333}.wp-theme-6 .ld .section-title{color:#fff}.wp-theme-6 .section-title.white{color:#fff;border-bottom:1px solid #fff}.wp-theme-6 .navbar-wp{margin:0;padding:0;border:0;border-radius:0;z-index:1000}.wp-theme-6 .lw .navbar-wp{background:#fff;border-bottom:1px solid #e0eded}.wp-theme-6 .ld .navbar-wp{background:#181818;border-bottom:1px solid #444}.wp-theme-6 .ld .sticky-wrapper .navbar-wp{background:rgba(24,24,24,0.85);border-bottom:1px solid #444}.wp-theme-6 .navbar-wp .navbar-nav>li>a{padding:28px 16px;margin-right:0;font-size:15px;font-weight:normal}.wp-theme-6 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-6 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-6 .lw .navbar-wp .navbar-nav>li>a{color:#333}.wp-theme-6 .lw .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#333}.wp-theme-6 .lw .navbar-wp .navbar-nav>li>a:hover,.wp-theme-6 .lw .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#d35400}.wp-theme-6 .ld .navbar-wp .navbar-nav>li>a{color:#fff}.wp-theme-6 .ld .navbar-wp .navbar-nav>li>a.dropdown-form-toggle{color:#fff}.wp-theme-6 .ld .navbar-wp .navbar-nav>li>a:hover,.wp-theme-6 .ld .navbar-wp .navbar-nav>li>a:focus{color:#fff;background-color:#d35400}.wp-theme-6 .navbar-wp .navbar-nav>.active>a,.wp-theme-6 .navbar-wp .navbar-nav>.active>a:hover,.wp-theme-6 .navbar-wp .navbar-nav>.active>a:focus{color:#fff !important;background-color:#d35400;border-radius:0}.wp-theme-6 .navbar-wp .navbar-nav>.disabled>a,.wp-theme-6 .navbar-wp .navbar-nav>.disabled>a:hover,.wp-theme-6 .navbar-wp .navbar-nav>.disabled>a:focus{color:#cccccc;background-color:transparent}.wp-theme-6 .navbar-wp .navbar-nav>.open>a,.wp-theme-6 .navbar-wp .navbar-nav>.open>a:hover,.wp-theme-6 .navbar-wp .navbar-nav>.open>a:focus{color:#FFF !important;background-color:#d35400}.wp-theme-6 .navbar-wp .navbar-nav>.open>a .caret,.wp-theme-6 .navbar-wp .navbar-nav>.open>a:hover .caret,.wp-theme-6 .navbar-wp .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-6 .navbar-wp .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-6 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle,.wp-theme-6 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-6 .navbar-wp .navbar-nav>li>a.dropdown-form-toggle:focus{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none;color:#d35400}.wp-theme-6 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle,.wp-theme-6 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:hover,.wp-theme-6 .navbar-wp .navbar-nav>.open>a.dropdown-form-toggle:focus{color:#d35400 !important;background-color:none}.wp-theme-6 .navbar-wp .navbar-toggle{border-color:#333;margin-top:20px}.wp-theme-6 .navbar-wp .navbar-toggle .icon-bar{background-color:#4c4c4c}.wp-theme-6 .navbar-wp .navbar-toggle .icon-custom{font-size:18px}.wp-theme-6 .navbar-wp .navbar-toggle:hover,.wp-theme-6 .navbar-wp .navbar-toggle:focus{background-color:#d35400;border-color:#d35400}.wp-theme-6 .navbar-wp .navbar-toggle:hover .icon-bar,.wp-theme-6 .navbar-wp .navbar-toggle:focus .icon-bar{background-color:#FFF}.wp-theme-6 .navbar-wp .navbar-toggle:hover .icon-custom,.wp-theme-6 .navbar-wp .navbar-toggle:focus .icon-custom{color:#FFF}.wp-theme-6 .navbar-wp .navbar-toggle-aside-menu{padding:8px 10px 2px 10px}.wp-theme-6 .navbar-wp .navbar-collapse,.wp-theme-6 .navbar-wp .navbar-form{border-color:#e7e7e7}.wp-theme-6 .navbar-wp .navbar-nav>.dropdown>a:hover .caret,.wp-theme-6 .navbar-wp .navbar-nav>.dropdown>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-6 .navbar-wp .dropdown-menu{min-width:220px;background:#FFF;border:0;border-top:1px solid #d35400;border-bottom:3px solid #d35400;border-radius:0}.wp-theme-6 .navbar-wp .dropdown-menu>li{border-bottom:1px solid #e0eded}.wp-theme-6 .navbar-wp .dropdown-menu>li:last-child{border:0}.wp-theme-6 .navbar-wp .dropdown-menu>li>a{color:#333;padding:8px 15px}.wp-theme-6 .navbar-wp .dropdown-menu>li>a:hover{background:#d35400;color:#FFF}.wp-theme-6 .navbar-wp .dropdown-menu label.checkbox{color:#333}.wp-theme-6 .navbar-wp .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-6 .navbar-wp .dropdown-menu-user{border:1px solid #e0eded;border-top-color:transparent}.wp-theme-6 .navbar-wp .dropdown-menu-user{background:#fff}.wp-theme-6 .navbar-wp .navbar-right .dropdown-menu-user{background:#fff;border-color:transparent}.wp-theme-6 .navbar-wp .navbar-right .social-link{width:40px;height:40px;line-height:20px;text-align:center;padding:10px;margin:18px 0;border-radius:100%}.wp-theme-6 .navbar-wp .navbar-right .social-link.facebook:hover{background:#43609c;color:#fff}.wp-theme-6 .navbar-wp .navbar-right .social-link.pinterest:hover{background:#cb2027;color:#fff}.wp-theme-6 .navbar-wp .navbar-right .social-link.twitter:hover{background:#62addb;color:#fff}.wp-theme-6 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-6 .lw .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-6 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:hover,.wp-theme-6 .ld .navbar-wp.navbar-contrasted .navbar-nav>li>a:focus{color:#fff;background-color:#2c2c2c}.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>.open>a,.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover,.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus{color:#FFF;background-color:#2c2c2c}.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>.open>a .caret,.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:hover .caret,.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>.open>a:focus .caret{border-top-color:#FFF;border-bottom-color:#FFF}.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>.dropdown>a .caret{border-top-color:#4c4c4c;border-bottom-color:#4c4c4c}.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle{padding:15px 16px;margin-top:14px;font-size:16px;font-weight:normal;background:none}.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:hover,.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav>li>a.dropdown-form-toggle:focus{background:none;color:#d35400}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{bottom:100%;right:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-right:-35px}.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{bottom:100%;left:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after{border-color:rgba(136,183,213,0);border-bottom-color:#2c2c2c;border-width:10px;margin-left:-35px}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu{min-width:220px;background:#2c2c2c;border:0;border-top:0;border-bottom:0;border-radius:0}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu>li{border-bottom:1px solid #262626}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu>li>a{color:#fff;padding:8px 15px}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu>li>a:hover{background:#d35400;color:#FFF}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox{color:#fff}.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-form h4{margin:0;padding:15px 15px 5px 15px;color:#FFF}.wp-theme-6 .dropdown-submenu{position:relative}.wp-theme-6 .dropdown-submenu>.dropdown-menu{top:-5px;left:100%;margin-top:0;margin-left:-1px}.wp-theme-6 .dropdown-submenu:hover>.dropdown-menu{display:block}.wp-theme-6 .dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:3px 0 3px 3px;border-left-color:#ccc;margin-top:5px;margin-right:-6px}.wp-theme-6 .dropdown-submenu:hover>a:after{border-left-color:#fff}.wp-theme-6 .dropdown-submenu.pull-left{float:none}.wp-theme-6 .dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px}.wp-theme-6 .nav>ul{margin:0;padding:0;list-style:none}.wp-theme-6 .nav>ul>li{border-bottom:1px solid #333}.wp-theme-6 .nav>ul>li>a{display:block;padding:10px 15px;font-size:14px;color:#fff}.wp-theme-6 .nav>ul>li>a:hover{text-decoration:none;color:#d35400;background:#292929}.wp-theme-6 .nav>ul>li>a>i{margin-right:5px}.wp-theme-6 .lw .pg-opt{border-bottom:1px solid #e0eded;background:#fcfcfc}.wp-theme-6 .ld .pg-opt{border-bottom:1px solid #444;background:#111}.wp-theme-6 .pg-opt.fixed{width:100%;position:fixed;top:0px;background:rgba(250,250,250,0.9);border-bottom:1px solid #e0eded;z-index:900}.wp-theme-6 .pg-opt h2{margin:0;padding:14px 0;font-size:22px;line-height:100%}.wp-theme-6 .pg-opt.fixed h2{margin-bottom:15px}.wp-theme-6 .pg-opt hr{margin:0;border-top-color:#dde1e6;-webkit-box-shadow:0 1px 0 #fbfbfc;-moz-box-shadow:0 1px 0 #fbfbfc;box-shadow:0 1px 0 #fbfbfc}.wp-theme-6 .pg-opt.fixed hr{display:none}.wp-theme-6 .pg-opt .breadcrumb{float:right;margin:0;padding:16px 0;background:none;border-radius:0}.wp-theme-6 .pg-opt .breadcrumb a{color:#d35400}@media only screen and (max-width:767px){.wp-theme-6 .pg-opt .pg-nav{float:left;margin-bottom:10px}.wp-theme-6 .pg-opt h2{padding:20px 0 0 0}}.wp-theme-6 .page-header{margin:0;border:0}.wp-theme-6 .page-header p{font-size:16px}.wp-theme-6 .w-box{margin:0 0 15px 0;-webkit-transition:all 0.3s linear;transition:all 0.3s linear;position:relative;overflow:hidden;cursor:default;border:1px solid #e0eded}.wp-theme-6 .w-box:before,.wp-theme-6 .w-box:after{display:table;content:""}.wp-theme-6 .w-box:after{clear:both}.wp-theme-6 .w-box h1{margin:0;padding:10px 15px;font-weight:500;font-size:20px}.wp-theme-6 .lw .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#333}.wp-theme-6 .ld .w-box h2{margin:0;padding:12px 15px 0px 15px;font-weight:500;font-size:16px;color:#fff}.wp-theme-6 .w-box.inner h2{padding:10px 0}.wp-theme-6 .w-box small{display:block;font-size:12px;margin-top:3px}.wp-theme-6 .w-box p{margin:6px 0;padding:0 15px;padding-bottom:8px}.wp-theme-6 .w-box time{display:block;padding:8px 15px 0 15px}.wp-theme-6 .w-box .w-footer{padding:10px 15px;border-top:1px solid #f1f1f1}.wp-theme-6 .w-box .w-footer:before,.wp-theme-6 .w-box .w-footer:after{display:table;content:""}.wp-theme-6 .w-box .w-footer:after{clear:both}.wp-theme-6 .w-box .w-footer small{font-size:12px}.wp-theme-6 .w-box .w-box-parent{-webkit-transition:all 0.3s linear;transition:all 0.3s linear}.wp-theme-6 .w-box .date-over{padding:10px;background:#fff;position:absolute;top:15px;right:15px;text-align:center;font-weight:normal}.wp-theme-6 .w-box .date-over.small{padding:4px 8px;font-size:12px}.wp-theme-6 .w-box .date-over strong{font-size:12px;display:block;font-weight:normal}.wp-theme-6 .w-box.dark{background:#333}.wp-theme-6 .w-box.dark h2{color:#fff}.wp-theme-6 .w-box.white h2{border-bottom:0;text-align:center}.wp-theme-6 .w-box.white .thmb-img{text-align:center;padding:15px 0}.wp-theme-6 .lw .w-box.white{background:#FFF}.wp-theme-6 .lw .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-6 .ld .w-box.white{background:#202020;border:1px solid #444}.wp-theme-6 .ld .w-box.white .thmb-img i{font-size:64px;color:#616161}.wp-theme-6 .w-box.w-box-inverse .thmb-img i{width:100px;height:100px;border-radius:100px;font-size:34px;line-height:100px;text-align:center}.wp-theme-6 .lw .w-box.w-box-inverse .thmb-img i{background:#fcfcfc;color:#d35400}.wp-theme-6 .ld .w-box.w-box-inverse .thmb-img i{background:#363636;color:#fff}.wp-theme-6 .w-box.w-box-inverse .thmb-img:hover i{background:#d35400;color:#FFF}.wp-theme-6 .c-box{border:1px solid #d35400}.wp-theme-6 .c-box .c-box-header{padding:10px 15px;background:#d35400;color:#fff;font-size:16px;text-transform:capitalize}.wp-theme-6 .c-box .table{margin:0}.wp-theme-6 .ld .w-section h4,.wp-theme-6 .ld .w-section h3,.wp-theme-6 .ld .w-section h2{color:#fff}.wp-theme-6 .w-section .aside-feature{margin:10px;cursor:default}.wp-theme-6 .w-section .aside-feature .icon-feature{font-size:68px;margin-top:10px;text-align:center;display:block}.wp-theme-6 .w-section .aside-feature:hover .icon-feature,.wp-theme-6 .w-section .aside-feature:hover h4{color:#d35400}.wp-theme-6 .w-section .aside-feature .img-feature{margin-top:4px;display:block}.wp-theme-6 .w-section .aside-feature .img-feature img{width:78px}.wp-theme-6 .layer-slider-wrapper{max-height:500px;overflow:hidden;border-bottom:1px solid #e0eded}.wp-theme-6 .layer-slider-wrapper .title{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-6 .layer-slider-wrapper .title.title-base{font-size:36px;line-height:46px;font-weight:500;color:#FFF;background:#e91b23;text-transform:capitalize}.wp-theme-6 .layer-slider-wrapper .title.title-dark{font-size:36px;line-height:46px;font-weight:500;color:#333;text-transform:capitalize}.wp-theme-6 .layer-slider-wrapper .subtitle{font-size:22px;line-height:30px;color:#d35400;text-transform:capitalize}.wp-theme-6 .layer-slider-wrapper .list-item{font-size:18px;line-height:30px;padding-left:30px;color:#d35400;text-transform:capitalize}.wp-theme-6 .layer-slider-wrapper .text-standard{font-size:16px;line-height:22px}.wp-theme-6 .box-element{padding:20px}.wp-theme-6 .box-element:nth-child(n+1){margin-top:20px}.wp-theme-6 .box-element h1{margin:10px 0 !important;font-size:20px;line-height:26px;font-weight:400}.wp-theme-6 .box-element.box-element-bordered{background:transparent !important;border:1px solid #d35400}.wp-theme-6 .box-element.box-element-outer{padding-left:0;padding-right:0}.wp-theme-6 .pricing-plans .plan-header .popular-tag{background:#333;border-bottom:1px solid #FFF;color:#fff}.wp-theme-6 .carousel-2{position:relative}.wp-theme-6 .carousel-2 .item{padding:36px 0 !important}.wp-theme-6 .carousel-2 .carousel-indicators{bottom:0}.wp-theme-6 .carousel-2 .carousel-indicators li{background-color:#f5f5f5;border:1px solid #ddd;border-radius:10px}.wp-theme-6 .carousel-2 .carousel-indicators .active{background-color:#d35400}.wp-theme-6 .carousel-2 .img-thumbnail{margin-top:26px}.wp-theme-6 .carousel-2 h2{font-size:22px}.wp-theme-6 .carousel-2 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:10px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#d35400;opacity:1}.wp-theme-6 .carousel-2 .carousel-nav a:hover{background:#d35400 !important;color:#fff}.wp-theme-6 .carousel-2 .carousel-nav a.left{right:36px}.wp-theme-6 .carousel-2 .carousel-nav a.right{right:0}.wp-theme-6 .carousel-2 .carousel-control i{position:absolute;top:50%;font-size:22px;margin-top:-11px}.wp-theme-6 .carousel-2 .carousel-control.left i{left:18px}.wp-theme-6 .carousel-2 .carousel-control.right i{right:18px}.wp-theme-6 .carousel-3{position:relative}.wp-theme-6 .carousel-3 .carousel-nav a{width:30px;height:30px;line-height:30px;position:absolute;top:-50px;right:0;margin-top:0;font-size:18px;text-align:center;border:1px solid transparent;background:#f5f5f5;color:#d35400;opacity:1}.wp-theme-6 .carousel-3 .carousel-nav a:hover{background:#d35400 !important;color:#fff}.wp-theme-6 .carousel-3 .carousel-nav a.left{right:36px}.wp-theme-6 .carousel-3 .carousel-nav a.right{right:0}.wp-theme-6 .carousel-3 .carousel-nav a:hover{background:#FFF}.wp-theme-6 .carousel-testimonials{position:relative;border:1px solid #e0eded}.wp-theme-6 .like-button .button{display:block;text-align:right;padding-top:10px;color:#ddd}.wp-theme-6 .like-button .button i{font-size:20px;color:#ddd}.wp-theme-6 .like-button .button.liked i{color:#d35400}.wp-theme-6 .like-button .count{display:block;text-align:right;position:relative;top:-7px}.wp-theme-6 .like-button.inline .button{display:inline-block;padding:0}.wp-theme-6 .like-button.inline .count{display:inline-block;top:-2px}.wp-theme-6 .like-button.inline .count small{font-size:13px}.wp-theme-6 .side-like-box{text-align:center;padding:5px 5px 0 5px;margin-top:10px}.wp-theme-6 .side-like-box .button{text-align:center;padding:0}.wp-theme-6 .side-like-box .count{text-align:center}.wp-theme-6 .side-like-box i{font-size:24px}.wp-theme-6 ul.list-listings{margin:0 0 20px 0;padding:0;list-style:none}.wp-theme-6 ul.list-listings li{margin-bottom:30px;border:1px solid #f3f3f3;overflow:hidden}.wp-theme-6 ul.list-listings li.featured{border-color:#d35400}.wp-theme-6 ul.list-listings li:before,.wp-theme-6 ul.list-listings li:after{content:"";display:table}.wp-theme-6 ul.list-listings li:after{clear:both}.wp-theme-6 ul.list-listings .listing-header{clear:both;padding:8px 15px;font-weight:600;text-transform:uppercase}.wp-theme-6 ul.list-listings .listing-image{width:25%;height:150px;float:left;overflow:hidden}.wp-theme-6 ul.list-listings .listing-body{width:50%;height:150px;padding:15px;float:left;background:#fcfcfc;border-right:1px solid #fcfcfc}.wp-theme-6 ul.list-listings .listing-body h3{margin:0;padding:0;font-size:18px;font-weight:500;line-height:25px}.wp-theme-6 ul.list-listings .listing-body h4{font-size:14px;font-weight:normal;line-height:22px}.wp-theme-6 ul.list-listings .listing-actions{width:25%;height:110px;padding-top:40px;float:left;text-align:center}.wp-theme-6 ul.list-listings .listing-actions .btn{margin-top:6px}.wp-theme-6 ul.list-check{list-style:none;margin:0;margin-bottom:15px;padding:0}.wp-theme-6 ul.list-check li{padding:4px 0;margin:0;display:block;width:100%}.wp-theme-6 ul.list-check li i{color:#d35400;font-style:normal;margin-right:4px}.wp-theme-6 ul.list-check li span{font-size:14px}.wp-theme-6 ul.categories{list-style:none;margin:0;padding:0 !important;border:1px solid #e0eded;overflow:hidden}.wp-theme-6 ul.categories li{border-bottom:1px solid #e0eded;position:reltive}.wp-theme-6 ul.categories li:last-child{border:0}.wp-theme-6 ul.categories li a{display:block;padding:10px 15px}.wp-theme-6 ul.categories li a:after{font-family:'FontAwesome';content:"\f105";position:relative;top:0;float:right}.wp-theme-6 ul.categories li a:hover{background:#d35400;color:#FFF;text-decoration:none}.wp-theme-6 ul.categories li a i{display:inline-block;vertical-align:middle;padding-right:5px;font-style:normal;color:#999;font-size:11px}.wp-theme-6 ul.categories li a:hover i{color:#FFF}.wp-theme-6 .timeline .year{width:100%;background:#333;padding:8px 10px;margin:20px auto 40px !important;font-size:20px}.wp-theme-6 .timeline .year{border-radius:3px}.wp-theme-6 .timeline .event{padding:0;border:1px solid #e0eded;border-radius:0}.wp-theme-6 .timeline .event:nth-child(2n):before{content:"";display:inline-block;position:absolute;right:-6.8% !important;top:20px;width:10px;height:10px;background:#d35400;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-6 .timeline .event:nth-child(2n-1):after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #FFF;border-top:12px solid transparent;border-bottom:12px solid transparent}.wp-theme-6 .timeline .event:nth-child(2n-1):before{content:"";display:inline-block;position:absolute;left:-6.5% !important;top:20px;width:10px;height:10px;background:#d35400;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}.wp-theme-6 .timeline .event-date{margin:0;background:#FFF;border-bottom:1px solid #e0eded;text-align:left;padding:10px 10px;font-weight:500;font-size:14px}.wp-theme-6 .timeline .event:nth-child(2n) .event-date:after{content:"";display:inline-block;position:absolute;right:-12px !important;top:12px;width:0;height:0;border-left:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-6 .timeline .event:nth-child(2n) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;right:-13px;width:0;height:0;border-left:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-6 .timeline .event:nth-child(2n-1) .event-date:after{content:"";display:inline-block;position:absolute;left:-12px !important;top:12px;width:0;height:0;border-right:12px solid #fff;border-top:12px solid transparent;border-bottom:12px solid transparent;z-index:20}.wp-theme-6 .timeline .event:nth-child(2n-1) .event-date:before{content:"";display:inline-block;position:absolute;top:11px;left:-13px;width:0;height:0;border-right:13px solid #ddd;border-top:13px solid transparent;border-bottom:13px solid transparent;z-index:0}.wp-theme-6 .timeline .event-date small{display:block;font-size:12px;color:#a1a1a1;font-weight:normal}.wp-theme-6 .timeline .event-date i{margin-right:7px}.wp-theme-6 .timeline .event-body{background:#f8f8f8}.wp-theme-6 .timeline .event-footer{margin:0;text-align:left;padding:8px 10px;background:none;border-top:1px solid #e0eded}.wp-theme-6 .timeline .event-footer:after,.wp-theme-6 .timeline .event-footer:before{display:table;content:" "}.wp-theme-6 .timeline .event-footer:after{clear:both}.wp-theme-6 .timeline .event img{margin:0}.wp-theme-6 .timeline p{padding:20px 10px;text-align:left}.wp-theme-6 .timeline iframe{margin:10px 0 0 0}.wp-theme-6 #toTop{display:none;text-decoration:none;position:fixed;bottom:10px;right:10px;overflow:hidden;width:40px;height:40px;border:none;text-indent:100%;background:#555;border-radius:3px}.wp-theme-6 #toTopHover{background:#d35400;width:40px;height:40px;display:block;overflow:hidden;float:left;opacity:0;-moz-opacity:0;filter:alpha(opacity=0)}.wp-theme-6 #toTop:active,.wp-theme-6 #toTop:focus{outline:none}.wp-theme-6 #toTop:before{font-family:'FontAwesome';content:"\f106";color:#ffffff;font-size:20px;position:absolute;top:50%;left:50%;width:20px;height:20px;text-align:center;line-height:20px;margin-top:-10px;margin-left:-10px;text-indent:0}.wp-theme-6 .widget.tags-wr{padding-bottom:15px}.wp-theme-6 .tags-list:before,.wp-theme-6 .tags-list:after{display:table;content:""}.wp-theme-6 .tags-list:after{clear:both}.wp-theme-6 .tags-list{list-style:none;padding-left:0;margin:0}.wp-theme-6 .tags-list li{border:1px solid #d35400;background:#FFF;padding:5px;float:left;margin-right:5px;margin-bottom:5px;color:#d35400;font-size:12px}.wp-theme-6 .tags-list li a{color:#d35400;margin-left:4px}.wp-theme-6 .tags-list li:hover{background:#d35400;color:#FFF}.wp-theme-6 .tags-list li:hover a{color:#FFF;text-decoration:none}.progress{height:28px;margin-bottom:15px;overflow:hidden;background-color:#f5f5f5;border-radius:2px;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1)}.progress .sr-only{width:auto;height:28px;margin:0;margin-left:30px;left:0;clip:auto;line-height:28px;font-size:14px}.progress-bar-one{background-color:#e06d58}.progress-bar-two{background-color:#697e93}.progress-bar-three{background-color:#3b3e43}.progress-bar-four{background-color:#FFF}div.tabs{margin-bottom:0}div.tabs:before,div.tabs:after{display:table;content:" "}div.tabs:after{clear:both}div.tabs div.tab-content{-moz-border-radius:none;-moz-box-shadow:none;-webkit-border-radius:0;-webkit-box-shadow:0;background-color:#FFF;border:1px solid #EEE;border-radius:0;border-top:0;box-shadow:none;padding:15px}div.tabs div.tab-content.tab-content-inverse{border:1px solid #EEE;background:transparent}div.tabs ul.nav-tabs{margin:0}div.tabs ul.nav-tabs li.active a{background:#fff;border-top:1px solid #ddd;color:#CCC}div.tabs ul.nav-tabs a{-moz-border-radius:0;-webkit-border-radius:0;border-radius:0;background:#f7f7f7;border:0;border-bottom:0;margin-right:0;color:#333}div.tabs ul.nav-tabs a:hover{border-top:1px solid #ddd;color:#7a92ac}div.tabs ul.nav-tabs a:active,div.tabs ul.nav-tabs a:focus{border-bottom:0}div.tabs-left ul.nav-tabs a:active,div.tabs-left ul.nav-tabs a:focus{border-right:0}div.tabs ul.nav-tabs a,div.tabs ul.nav-tabs a:hover{border:1px solid #EEE;border-right:0;border-top:1px solid #ddd;font-size:0.9em}div.tabs ul.nav-tabs a:last-child,div.tabs ul.nav-tabs a:last-child:hover{border-right:1px solid #ddd}div.tabs-left ul.nav-tabs a,div.tabs-left ul.nav-tabs a:hover{border:1px solid #EEE;border-right:0;border-left:2px solid #DDD;color:#CCC;font-size:0.9em}div.tabs-right ul.nav-tabs a,div.tabs-right ul.nav-tabs a:hover{border:1px solid #EEE;border-left:0;border-right:2px solid #DDD;color:#CCC;font-size:0.9em}.tabbable.tabs-left{-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;margin-bottom:30px}div.tabbable.tabs-left div.tab-content{-moz-border-radius:0 0 2px 2px;-moz-box-shadow:1px 1px 5px 0 rgba(0,0,0,0.04);-webkit-border-radius:0 0 2px 2px;-webkit-box-shadow:1px 1px 5px 0 rgba(0,0,0,0.04);background-color:#FFF;border:1px solid #EEE;border-radius:0 0 2px 2px;border-left:0;box-shadow:1px 1px 5px 0 rgba(0,0,0,0.04);padding:15px}div.tabbable.tabs-left ul.nav-tabs a{-moz-border-radius:2px 2px 0 0;-webkit-border-radius:2px 2px 0 0;background:#f7f7f7;border:1px solid #EEE;border-right:0;border-radius:2px 2px 0 0;color:#666;margin-bottom:3px}div.tabbable.tabs-left ul.nav-tabs li.active a{background:#fff;color:#CCC}.tabbable.tabs-right{-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;margin-bottom:30px}div.tabbable.tabs-right div.tab-content{-moz-border-radius:0 0 2px 2px;-moz-box-shadow:1px 1px 5px 0 rgba(0,0,0,0.04);-webkit-border-radius:0 0 2px 2px;-webkit-box-shadow:1px 1px 5px 0 rgba(0,0,0,0.04);background-color:#FFF;border:1px solid #EEE;border-radius:0 0 2px 2px;border-left:0;margin:0;box-shadow:1px 1px 5px 0 rgba(0,0,0,0.04);padding:15px}div.tabbable.tabs-right ul.nav-tabs a{-moz-border-radius:2px 2px 0 0;-webkit-border-radius:2px 2px 0 0;background:#f7f7f7;border:1px solid #EEE;border-left:0;border-radius:2px 2px 0 0;color:#666;margin-bottom:3px}div.tabbable.tabs-right ul.nav-tabs li.active a{background:#fff;color:#CCC}.tabs-centered{width:100%;display:table;margin:0 auto}.tabs-centered ul li{width:100px;display:inline-block;float:none}.nav-pills{margin-bottom:15px;border:1px solid #EEE}.nav-pills>li>a{border-radius:0;border-right:1px solid #e0eded}.nav-pills>li:last-child>a{border-radius:0;border-right:0}.nav-pills>li>a:hover,.nav-pills>li>a:focus{background:#f5f5f5}.nav-pills>li+li{margin-left:2px}.nav-pills>li.active>a,.nav-pills>li.active>a:hover,.nav-pills>li.active>a:focus{color:#e91b23;background:none}.panel{-webkit-box-shadow:none;box-shadow:none}.panel-group{margin-bottom:30px}.panel-group .panel{border-radius:0}.panel-group .panel+.panel{margin-top:0;border-top:0}.panel-group .panel-heading{padding:14px 15px;position:relative}.panel-group .panel-heading:after{content:"+";font-size:12px;position:absolute;right:15px;top:50%;margin-top:-8px}.panel-group .panel-heading:after{content:"+";font-size:12px;position:absolute;right:15px;top:50%;margin-top:-8px}.panel-group .panel-heading a{font-weight:normal}.panel-group .panel-heading a i{margin-right:5px;color:#e91b23}.panel{border-radius:0}.panel .panel-heading{border-radius:0}.modal-footer{margin-top:0}.alert{border-radius:0}.table>thead>tr>th{border-bottom:1px solid #ddd}.table>thead>tr{background:#f3f3f3}iframe{border:0;margin-top:0 !important}h1.font-lg{font-size:100px;font-weight:600}.no-padding{padding:0 !important}.no-margin{margin:0 !important}.p-15{padding:15px !important}.p-50{padding:50px 0 !important}.pb-10{padding-bottom:10px}.pb-20{padding-bottom:20px}.pt-10{padding-top:10px}.pt-20{padding-top:20px}.pl-20{padding-left:20px}.mt-20{margin-top:20px}.mb-20{margin-bottom:20px}.padding-y-10{padding:10px 0}.padding-x-4{padding:0 4px}.padding-x-8{padding:0 8px}.padding-x-16{padding:0 16px}.padding-x-20{padding:0 20px}.padding-x-32{padding:0 32x}.padding-y-20{padding:20px 0 !important}.margin-b-10{margin-bottom:10px}.margin-b-20{margin-bottom:20px}.margin-t-15{margin-top:15px}.margin-t-20{margin-top:20px}.margin-y-10{margin:10px 0}.margin-y-20{margin:20px 0}.margin-x-20{margin:0 20px}.strong{font-weight:bold !important}.img-center{display:block;margin-left:auto;margin-right:auto}.bg-banner-1{padding:54px 0 !important;background:url(../images/prv/banner-img-4.jpg) fixed no-repeat !important;color:#fff}.bg-banner-2{padding:54px 0 !important;background:url(../images/prv/banner-img-1.jpg) no-repeat fixed !important;color:#fff}.mask-dark{display:none;position:relative;top:0;left:0;width:100%;height:100%;background:url(../images/background/slash_it.png);opacity:0.4}.img-thumbnail{border-radius:0}.blockquote-1{margin-top:20px}header{padding:0}header .navbar-brand{padding:0 15px;margin-top:14px;border:1px solid transparent;border-radius:3px}header .navbar-brand img{height:46px}header .navbar-fixed{width:100%;left:0}header .navbar-fixed .navbar{width:100%}.top-header{border-bottom:1px solid #eee;background:#fff}.top-header .aux-text{padding:10px 0;color:#999;font-size:11px}.top-header .top-header-menu{float:right}.top-header .top-header-menu>ul.menu{list-style:none;margin:0;padding:0}.top-header .top-header-menu>ul.menu>li{position:relative;float:left;display:inline-block;border-right:1px solid #eee}.top-header .top-header-menu>ul.menu>li:last-child{border:0}.top-header .top-header-menu>ul.menu>li>a{display:block;padding:10px 15px;color:#333}.top-header .top-header-menu>ul.menu>li.dropdown>a:after{content:"\f107";margin-left:6px;font-family:"FontAwesome";position:relative;float:right}.top-header .top-header-menu ul.menu>li>a>i{margin-right:6px}.top-header .top-header-menu ul.menu>li ul.sub-menu{display:none;min-width:160px;position:absolute;right:-1px;z-index:1500;margin:0;padding:0;list-style:none;background:#fff;border:1px solid #eee;opacity:0;-moz-opacity:0;filter:alpha(opacity=0);-webkit-box-shadow:0 6px 12px rgba(0,0,0,0.175);-moz-box-shadow:0 6px 12px rgba(0,0,0,0.175);box-shadow:0 6px 12px rgba(0,0,0,0.175);-webkit-transition:all .2s ease-in-out;-moz-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.top-header .top-header-menu ul.menu>li:hover ul.sub-menu{opacity:1;display:block}.top-header .top-header-menu ul.menu>li ul.sub-menu>li{border-bottom:1px solid #eee}.top-header .top-header-menu ul.menu>li ul.sub-menu>li:last-child{border:0}.top-header .top-header-menu ul.menu>li ul.sub-menu>li>a{display:block;padding:6px 15px;color:#33}.top-header .top-header-menu ul.menu>li ul.sub-menu>li>.language-active{display:block;padding:6px 15px;background:#f8f8f8;cursor:default}.top-header .top-header-menu ul.menu>li.dropdown:hover .sub-menu{display:block}.top-header.top-header-dark{border-bottom:1px solid #222;background:#020202}.top-header.top-header-dark .aux-text{color:#fff}.top-header.top-header-dark .top-header-menu>ul.menu>li{border-color:#222}.top-header.top-header-dark .top-header-menu>ul.menu>li>a{color:#fff}.dropdown-form{min-width:300px;z-index:500}.dropdown-cart{min-width:400px;padding:15px}.dropdown-cart .cart-items{display:block;margin-bottom:15px;font-size:14px;font-wight:500}.dropdown-menu h4{font-size:14px;color:#4c4c4c}.dropdown-profile{padding:15px}.dropdown-profile img{width:60px}.aside-menu-in .wrapper{left:-280px}.wrapper{position:relative;left:0;-webkit-transition:all 300ms cubic-bezier(.25, .46, .45, .94);-moz-transition:all 300ms cubic-bezier(.25, .46, .45, .94);-o-transition:all 300ms cubic-bezier(.25, .46, .45, .94);transition:all 300ms cubic-bezier(.25, .46, .45, .94);-webkit-transition-timing-function:cubic-bezier(.25, .46, .45, .94);-moz-transition-timing-function:cubic-bezier(.25, .46, .45, .94);-o-transition-timing-function:cubic-bezier(.25, .46, .45, .94);transition-timing-function:cubic-bezier(.25, .46, .45, .94)}.aside-menu{width:280px;height:100%;overflow-y:scroll;position:fixed;right:0;top:0;background:#222222;border-left:1px solid #333;display:none}.aside-menu::-webkit-scrollbar{display:none !importat;width:0 !important}.aside-menu .form-search{margin:0;padding:0;border-bottom:1px solid #333}.aside-menu .form-search .form-input{padding:0}.aside-menu .form-search .form-control{display:block;height:34px;padding:21px 15px;color:#fff;background-color:transparent;border:0;border-radius:0;-webkit-box-shadow:none;box-shadow:none;-webkit-transition:none}.aside-menu .form-search .btn-close{background:transparent;color:#fff}.aside-menu .form-search .btn-close i{font-weight:300 !important;font-size:16px}.aside-menu .social-media{padding:15px;padding-bottom:0}.aside-menu .contact-info{padding:15px;color:#fff}.aside-menu .contact-info h5{font-size:12px}.side-section-title{position:relative;overflow:hidden;margin:0;margin-top:15px;padding:8px 15px;font-size:11px;text-transform:uppercase;color:#616161}.side-section-title:after{content:"";height:1px;background:#333;width:80px;position:absolute;top:26px;left:15px}.style-switcher-slidebar{width:310px;height:420px;position:fixed;left:-260px;top:130px;z-index:10999;-webkit-transition:all 0.5s ease;-moz-transition:all 0.5s ease;-o-transition:all 0.5s ease;-ms-transition:all 1s ease;transition:all 0.5s ease}.style-switcher-slidebar.opened{left:0}.style-switcher-slidebar .switch-panel{float:left;width:255px;height:370px;background:#fff;color:#333333;box-shadow:1px 1px 3px rgba(0,0,0,0.3)}a.open-panel{text-align:center;line-height:50px;font-size:30px;color:#fff !important;background-color:#e91b23;display:block;height:50px;width:50px;float:right;margin:0;z-index:1000;position:relative;-webkit-transition:none;-moz-transition:none;-o-transition:none}a.open-panel:hover{color:#fff}.style-switcher-slidebar label{margin-bottom:0}.style-switcher-slidebar h3{height:50px;line-height:50px;margin:0 0 10px 0;padding:0 10px;background:#e91b23;font-size:16px;color:#fff}.style-switcher-slidebar .panel-section{padding:0 15px}.color-picker{display:block}.color-picker a{width:30px;height:30px;display:inline-block;margin-right:5px;margin-bottom:8px;text-indent:-9999px}.color-picker a:last-child{margin-right:0}.color-picker a.color-red{background:#e91b23}.color-picker a.color-violet{background:#563d7c}.color-picker a.color-blue{background:#59b2e5}.color-picker a.color-green{background:#8ec449}.color-picker a.color-yellow{background:#f1c40f}.color-picker a.color-orange{background:#d35400}.search-wr{width:100%;height:110px;background:#FFF;position:fixed;top:0;z-index:2200;display:none;-webkit-box-shadow:0 1px 10px rgba(0,0,0,0.1);-moz-box-shadow:0 1px 10px rgba(0,0,0,0.1);box-shadow:0 1px 10px rgba(0,0,0,0.1)}.search-wr .close{display:block;width:22px;height:22px;position:relative;float:right;top:10px;right:10px}.search-wr .close i{font-size:20px;color:#555}.search-wr .search-sign i{font-size:60px;line-height:110px;color:#DDD}.global-search-input{padding:40px 0 0 0;font-size:20px;position:relative;width:740px;background:#fff;z-index:10;border:none;outline:none;color:#DDD}.global-search-input:focus{color:#333}.carousel-1{overflow:hidden}.carousel-1 .carousel-inner{height:440px}.carousel-1 .carousel-control{color:#f8f8f8}.carousel-1 .carousel-control.left{left:-40px}.carousel-1 .carousel-control.right{right:-40px}.carousel-1 .carousel-control:hover{color:#fff}.carousel-1 .carousel-control i{position:absolute;top:50%;margin-top:-18px;font-size:36px;font-weight:600}.carousel-1 .item{height:440px}.carousel-1 .item{background-repeat:no-repeat;background-size:cover;background-position:0% 0%}.carousel-1 .item-dark{color:#FFF}.carousel-1 .item-light{color:#fff}.carousel-1 p{font-size:16px}.carousel-1 .object{position:absolute;top:38px;right:50%;margin-left:15px;width:568px;height:320px;overflow:hidden}.carousel-1 .object.fluid{width:100%;left:0;margin:0}.carousel-1 .object iframe{width:100% !important}.carousel-1 .description{position:absolute;top:55px;left:50%;margin-left:50px;width:514px;height:290px}.carousel-1 .description .title{font-size:32px;margin:0 0 15px 0;padding:8px 20px;line-height:38px;background:#FFF;color:#616161}.carousel-1 .description .subtitle{font-size:24px;margin:20px 0;padding:0;display:block}.carousel-1 .description p{font-size:16px;color:#FFF;margin:0}.carousel-1 .description.fluid-center{width:100%;top:50px;left:0;margin:0}.carousel-1 .description.fluid-center .title{margin-bottom:5px;display:block;text-align:center;background:none;color:#FFF;font-weight:500;text-shadow:1px 1px 3px rgba(150,150,150,0.5)}.carousel-1 .description.fluid-center .subtitle{font-size:20px;margin:0;display:block;text-align:center}.carousel-1 .description.fluid-center .features{display:block;margin-top:40px;text-align:center}.carousel-1 .description.fluid-center .features i{width:110px;height:110px;background:#FFF;text-align:center;line-height:110px;font-size:54px;color:#697e93;font-weight:700;border-radius:96px;margin-right:20px}.carousel-4 .carousel-inner{overflow:hidden}.carousel-4 .carousel-control i{position:absolute;top:50%;margin-top:-18px;font-size:36px;font-weight:600}.slider-wrapper *{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;font-family:"Roboto",sans-serif}.slider-wrapper{position:relative;overflow:hidden;width:100%;max-height:440px;margin:0 auto;background:#f2f2f2;z-index:800}.slider{position:relative;width:100%;margin:0 auto;background:#f2f2f2}.slider-wrapper p{margin:0;padding:0;border:0;outline:0;font-size:100%;font:inherit;vertical-align:baseline}.slider-wrapper p{position:absolute;top:-200px;z-index:8000;padding:1% 2%;font-size:24px;line-height:100%;white-space:nowrap;text-transform:uppercase}.slider-wrapper .white{color:#FFF}.slider-wrapper .claim{line-height:100%}.slider-wrapper .teaser{font-size:14px;line-height:100%}.slider-wrapper .small{width:250px;text-align:center}.slider-wrapper .video{width:540px;height:360px;font-size:13px;line-height:18px;white-space:normal;text-align:left;text-transform:none}.slider-wrapper .video iframe{width:100%}.slider-wrapper .text{width:460px;font-size:13px;padding:0 2%;line-height:18px;white-space:normal;text-align:left;text-transform:none}.slider-wrapper .text a{margin-top:20px}.slider-wrapper .slide-light p{color:#FFF}.slider-wrapper .slide-light p.claim{width:50%;white-space:normal;maring-bottom:20px}.slider-wrapper .slide-light p.teaser{font-weight:300}.simple-slider{height:500px;background:#f3f3f3}.cta-wr{padding:16px 0}.cta-wr h1{margin:10px 0 !important;font-size:20px;line-height:26px;font-weight:400}section.slice{padding:30px 0;background:#fff}section.slice.relative{position:relative}.subsection{margin-top:30px}.container.bordered{border:1px solid #ddd;padding-top:15px}.w-box:hover .w-box-parent{-webkit-transform:translateY(-40px);-moz-transform:translateY(0);-ms-transform:translateY(0);-o-transform:translateY(0);-webkit-transition:-webkit-transform .4s;-moz-transition:-moz-transform .4s;-o-transition:-o-transform .4s;transition:transform 0.4s}.w-box .w-box-parent .w-box-button.animated{position:absolute;bottom:10px;margin-bottom:-40px;-webkit-transition:all 0.3s linear;transition:all 0.3s linear}.w-box.w-box-inverse{background:none !important;border:0;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.w-box.w-box-inverse p{padding:0}.w-box.w-box-inverse h1{margin:10px 0 0 0;padding:10px 0;font-weight:500;font-size:20px}.w-box.w-box-inverse h2{margin:15px 0 0 0;padding:0;font-weight:500;font-size:16px;text-transform:none;border:0;text-align:center}.w-box.w-box-inverse h2 i{font-style:normal}.w-box.w-box-inverse ul.meta-list{maring:0;padding:0}.w-box.w-box-inverse .w-footer{padding:10px 0}.w-box.w-box-inverse .thmb-img{text-align:center}.w-box.dark p{color:#f1f1f1}.w-box.dark h2{color:#FFF;text-align:center;margin-bottom:7px}.w-box.dark .thmb-img{text-align:center;padding:15px 0}.w-box.dark .thmb-img i{font-size:64px;color:#FFF}.w-box.product{background:#FFF;padding-top:15px;margin-bottom:20px}.w-box.product .figure{padding:20px}.w-box.product p{text-align:center}.w-box.product h2{border-bottom:0;text-align:center}.w-box.product .thmb-img{text-align:center;padding:15px 0}.w-box.product .thmb-img i{font-size:64px;color:#616161}.w-box.product .price{padding:4px 0}.w-box.inverse{background:none;border:0}.w-box.inverse p{padding:4px 0}.w-box.inverse h2{padding:10px 0 0 0 !important;border-bottom:0}.w-box.inverse .thmb-img{padding:15px 0}.w-box.inverse .thmb-img i{font-size:64px;color:#616161}.w-box.inverse .social-icons{border:0 }.w-section{background:#FFF}.w-section:before,.w-section:after{display:table;content:" "}.w-section:after{clear:both}.w-section.inverse{background:none !important;-moz-box-shadow:0 0 0;-webkit-box-shadow:0 0 0;box-shadow:0 0 0;border:0}.w-section.inner{margin:15px 0}.w-section iframe{width:100%}.w-section .feature{margin:15px 0 30px 0;text-align:center;cursor:default}.w-section .feature i{font-size:64px;color:#555;display:block}.w-section .feature h4{margin:10px 0}.w-section .aside-feature h4{margin:10px 0}.w-section .txt-feature{margin:15px 0 30px 0;cursor:default}.w-section .txt-feature h4{margin:0;padding:0;margin-bottom:10px;font-weight:500}.w-section .txt-fly-over{height:350px;overflow:hidden;position:absolute;top:-90px;z-index:1000;padding:20px}.w-section .txt-fly-over h1{padding:0;margin:0;margin-bottom:10px;font-size:54px;font-weight:600;color:#FFF}.w-section .txt-fly-over h2{padding:0;margin:0 0 20px 0;font-size:24px;font-weight:500}.w-section .inline-features i{display:block;margin-bottom:15px;height:64px;line-height:64px;text-align:center;font-size:40px;background:#555;color:#fff;border-radius:3px;-moz-border-radius:3px;-webkit-border-radius:3px}.w-section .inline-features i:hover{background:#75b918}.w-section .contrast-box{padding:15px;margin-bottom:20px;border-radius:3px;border:1px solid #f3f3f3}.w-section .contrast-box i{font-size:24px;margin-right:8px}.w-section .contrast-box small{display:block;margin-top:12px;font-style:italic;text-align:right}.wp-example{margin-bottom:45px}.wp-example pre{border-radius:0;margin-top:20px}.nav-sidebar-fixed{position:fixed;width:260px}.shop .pagination{margin:0}.shop .product-short-info p{padding:6px 0;margin:0}.shop .primary-image{border:1px solid #f3f3f3;padding:10px}.shop .thumbnail-images{margin:10px 0 25px 0}.shop .thumbnail-images a{display:inline-block;width:100px;height:100px;padding:10px;overflow:hidden;margin-right:5px;border:1px solid #f3f3f3}.shop .thumbnail-images a:last-child{margin:0}.shop .thumbnail-images a img{width:100%}.table-cart{border:1px solid #ddd}.table-cart td{vertical-align:middle}.table-cart td:first-child{border-right:1px solid #ddd}.table-cart img{width:80px}.dropdown-cart .table-cart img{width:50px}.table-cart .cart-remove{display:block;text-align:center;color:#e80e1d}.table-totals td:nth-child(even){padding:5px 15px}.animate-wr{animation-duration:0.5s;-webkit-animation-duration:0.5s;-moz-animation-duration:1s;-o-animation-duration:1s}.animate-hover-slide .figure{position:relative;overflow:hidden}.animate-hover-slide .figure img{-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide .figure .figcaption{height:100%;padding:0;width:100%;position:absolute;left:0;top:auto;bottom:0;opacity:0;-webkit-transform:translateY(100%);-moz-transform:translateY(100%);-ms-transform:translateY(100%);-o-transform:translateY(100%);-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide .figure:hover .figcaption{opacity:0.8;-webkit-transform:translateY(0);-moz-transform:translateY(0);-ms-transform:translateY(0);-o-transform:translateY(0);-webkit-transition:-webkit-transform .4s,opacity .1s;-moz-transition:-moz-transform .4s,opacity .1s;-o-transition:-o-transform .4s,opacity .1s;transition:transform 0.4s, opacity 0.1s}.animate-hover-slide .figure .figcaption{text-align:center}.animate-hover-slide .figure .figcaption-btn{width:100%;height:50%;position:absolute;top:0px;opacity:0;padding-left:20px;text-align:center;-webkit-transform:translateY(-100%);-moz-transform:translateY(-100%);-ms-transform:translateY(-100%);-o-transform:translateY(-100%);-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide .figure:hover .figcaption-btn{opacity:1;-webkit-transform:translateY(0);-moz-transform:translateY(0);-ms-transform:translateY(0);-o-transform:translateY(0);-webkit-transition:-webkit-transform .4s,opacity .1s;-moz-transition:-moz-transform .4s,opacity .1s;-o-transition:-o-transform .4s,opacity .1s;transition:transform 0.4s, opacity 0.1s}.animate-hover-slide .figure .figcaption-txt{width:100%;height:50%;position:absolute;bottom:0px;opacity:0;padding-left:20px;text-align:center;-webkit-transform:translateY(100%);-moz-transform:translateY(100%);-ms-transform:translateY(100%);-o-transform:translateY(100%);-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide .figure:hover .figcaption-txt{opacity:1;-webkit-transform:translateY(0);-moz-transform:translateY(0);-ms-transform:translateY(0);-o-transform:translateY(0);-webkit-transition:-webkit-transform .4s,opacity .1s;-moz-transition:-moz-transform .4s,opacity .1s;-o-transition:-o-transform .4s,opacity .1s;transition:transform 0.4s, opacity 0.1s}.animate-hover-slide .figure .figcaption-txt .title{padding:0;margin:30px 0 0 0;color:#fff;font-size:18px;text-transform:capitalize}.animate-hover-slide .figure .figcaption-txt .subtitle{padding:0;margin:0;color:#fff;font-size:12px}.animate-hover-slide .figure a{position:relative;top:94%;margin-top:-11px}.animate-hover-slide .figure .figcaption h3{padding-bottom:5px;margin-bottom:10px;font-size:14px;font-weight:600;border-bottom:1px solid #f2f2f2}.animate-hover-slide-2 .figure{position:relative;overflow:hidden}.animate-hover-slide-2 .figure img{position:relative;z-index:2;-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide-2 .figure:hover img{-webkit-transform:scale(.4);-moz-transform:scale(.4);-ms-transform:scale(.4);transform:scale(.4)}.animate-hover-slide-2 .figure .figcaption{height:100%;z-index:1;position:absolute;top:0;bottom:auto;background:#f8f8f8;padding:0 15px;width:100%;opacity:1;-webkit-transform:scale(.4);-moz-transform:scale(.4);-ms-transform:scale(.4);transform:scale(.4);-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide-2 .figure:hover .figcaption{-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);opacity:1}.animate-hover-slide-2 .figure .figcaption h2{text-align:center;margin-top:15px}.animate-hover-slide-2 .figure .figcaption .social-icons{width:100%;position:absolute;bottom:15px;text-align:center}.animate-hover-slide-3 .figure{position:relative;overflow:hidden}.animate-hover-slide-3 .figure img{-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide-3 .figure .figcaption{height:32px;background:#f8f8f8;padding:0 15px;width:100%;position:absolute;left:0;top:auto;bottom:0;opacity:0;-webkit-transform:translateY(100%);-moz-transform:translateY(100%);-ms-transform:translateY(100%);-o-transform:translateY(100%);-webkit-transition:-webkit-transform .4s,opacity .1s .3s;-moz-transition:-moz-transform .4s,opacity .1s .3s;-o-transition:-o-transform .4s,opacity .1s .3s;transition:transform 0.4s, opacity 0.1s 0.3s}.animate-hover-slide-3 .figure:hover .figcaption{opacity:1;-webkit-transform:translateY(0);-moz-transform:translateY(0);-ms-transform:translateY(0);-o-transform:translateY(0);-webkit-transition:-webkit-transform .4s,opacity .1s;-moz-transition:-moz-transform .4s,opacity .1s;-o-transition:-o-transform .4s,opacity .1s;transition:transform 0.4s, opacity 0.1s}.pricing-plans{margin-bottom:15px}.pricing-plans:before,.pricing-plans:after,.pricing-table:before,.pricing-table:after{display:table;content:" "}.pricing-plans:before,.pricing-table:before{clear:both}.pricing-plans .plan-header{padding-bottom:15px}.pricing-plans .plan-header .popular-tag{padding:5px 0;text-align:center;text-transform:uppercase}.pricing-plans .plan-header small{display:block;text-align:center;font-style:italic}.pricing-plans .plan-title{text-align:center;margin:0;font-size:28px;font-weight:500;color:#fff}.pricing-plans .price-tag{margin:0;height:70px;line-height:70px;font-size:58px;font-weight:500;text-align:center}.pricing-plans .price-tag span{font-size:28px;font-weight:500}.pricing-plans .price-tag span.price-type{font-size:20px;font-weight:500}.pricing-plans ul{margin:0;padding:0;list-style:none}.pricing-plans ul li{padding:10px 20px;border-bottom:1px solid #f1f1f1;font-size:13px}.pricing-plans ul li:last-child{border-bottom:0}.pricing-plans ul li i{margin-right:8px}.pricing-plans .plan-info{margin:0;padding:15px;font-size:13px;text-align:center;font-style:italic}.pricing-plans .plan-select{padding:15px 0;border-top:1px solid #f1f1f1}.pricing-plans .plan-circle{height:263px;padding:0 25px;display:table-cell;vertical-align:middle;border-radius:200%}.pricing-plans .plan-circle .btn{margin-top:10px}.pricing-plans .w-box{margin-top:20px}.pricing-plans .w-box:hover,.pricing-table .w-box:hover{-webkit-box-shadow:0 -4px 14px rgba(0,0,0,0.2);-moz-box-shadow:0 -4px 14px rgba(0,0,0,0.2);box-shadow:0 -4px 14px rgba(0,0,0,0.2)}.pricing-plans .w-box-inverse:hover,.pricing-table .w-box-inverse:hover{-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.pricing-table .w-box{z-index:1;margin-top:20px;margin-bottom:0;-webkit-box-shadow:none;-moz-box-shadow:0;box-shadow:none}.pricing-table .w-box.popular,.pricing-plans .w-box.popular{margin-top:0;-webkit-box-shadow:0 -4px 14px rgba(0,0,0,0.2);-moz-box-shadow:0 -4px 14px rgba(0,0,0,0.2);box-shadow:0 -4px 14px rgba(0,0,0,0.2)}.pricing-table .w-box.popular:hover,.pricing-plans .w-box.popular:hover{-webkit-box-shadow:0 -4px 14px rgba(0,0,0,0.3);-moz-box-shadow:0 -4px 14px rgba(0,0,0,0.3);box-shadow:0 -4px 14px rgba(0,0,0,0.3)}.pricing-table .plan-select{margin-top:0;border:0;margin-bottom:15px;border-bottom:1px solid #f1f1f1}.pricing-table .plan-info{text-align:center;margin-bottom:15px}.pricing-table .table-comparision{background:#FFF;position:relative;top:-2px;z-index:1000;border-color:#f1f1f1;color:#777}.pricing-table .table-comparision th{border-color:#f1f1f1}.pricing-table .table-comparision td{text-align:center;border-color:#f1f1f1}.pricing-table .table-comparision tr td:first-child{text-align:left}.vertical-info h4{margin:0;padding:0;font-size:16px}.vertical-info p.delimiter{margin:10px 0;padding-bottom:10px;border-bottom:1px solid #e0dede}#ulSorList{margin-top:20px}#ulSorList:after{content:'';display:inline-block;width:100%}#ulSorList .mix{display:none;opacity:0}#ulSorList .mix .item{background:#f2f2f2}#ulSorList .gap{display:inline-block;width:200px}.work{width:100%;overflow:hidden}.work .btn-group{margin-bottom:10px}.work .btn{margin-right:6px}.work .btn-group .btn{margin-right:0}.work .mix{margin-top:20px}.work.work-no-space.g2 .mix{width:50%;display:inline-block;float:left;margin:0;padding:0}.work.work-no-space.g3 .mix{width:33.3%;display:inline-block;float:left;margin:0;padding:0}.work.work-no-space.g4 .mix{width:25%;display:inline-block;float:left;margin:0;padding:0}.work.work-no-space.g5 .mix{width:20%;display:inline-block;float:left;margin:0;padding:0}.work.work-no-space .mix .w-box{padding:0;margin:0}.map-canvas{height:300px;margin:0}.map-canvas .info-window-content{min-width:250px}.map-canvas .info-window-content h2{font-size:18px;font-weight:600;margin-bottom:8px}.map-canvas .info-window-content h3{font-size:14px;font-weight:500}.map-canvas .info-window-content p{margin-top:20px;text-align:center;font-size:12px;color:#999;text-shadow:none}.comments-wr{padding:0 15px}.comments-wr .comment:before,.comments-wr .comment:after{display:table;content:" "}.comments-wr .comment:after{clear:both}.comments-wr .comment{border-bottom:1px solid #eee;padding:15px 0}.comments-wr .comment:last-child{border-bottom:0}.comments-wr .comment p{padding:0}.comments-wr .comment .comment{margin:12px 0 0 60px;padding-bottom:0;border-bottom:0;border-top:1px solid #eee}.comments-wr .comment img{width:48px;float:left}.comments-wr .comment p{margin-left:60px;color:#777}.comments-wr .comment .comment-author{display:block}.comments-wr .comment .comment-author a{font-weight:600}.comment-form{padding:15px 15px}.comment-form h2{margin-bottom:15px}.widget{margin-bottom:20px}.widget-highlight{padding:15px;background:#fcfcfc;border:1px solid #f3f3f3}.video-container iframe{margin:0;border:0}.media-photos-list{padding-left:0;list-style:none;margin-bottom:0;overflow:hidden}.media-photos-list>li{float:left;margin-right:6px;margin-bottom:6px}.media-photos-list>li img{width:60px;height:60px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.media-photos-list>li img:hover{opacity:0.65;filter:alpha(opacity=65)}ul.list-1{padding:0;margin:0;list-style:none}ul.list-1 li{margin:15px 0}ul.list-1 time{float:left;display:inline-block;background:#e74c3c;color:#FFF;font-weight:600;padding:5px 8px;border-radius:2px}ul.list-1 .txt:before{content:"";position:absolute;margin-left:-10px;margin-top:6px;width:0;height:0;border-top:10px solid transparent;border-right:10px solid #f3f3f3;border-bottom:10px solid transparent}ul.list-1 .txt{margin-left:62px;margin-top:20px;background:#f3f3f3}ul.list-1 .txt p{padding:8px 15px;margin:0}ul.list-2{-webkit-padding-start:20px;margin:15px 0}ul.list-2 li{padding-left:15px;list-style-type:none;background:url(../images/list-style-2.png) no-repeat 0 8px;color:#555}ul.list-2 li a{color:#555}ul.list-2 li a:hover{color:#83ae34;text-decoration:none}ul.list-3{margin:0;list-style:none}ul.list-3 li{height:58px;background:#f2f2f2;overflow:hidden;margin-bottom:13px}ul.list-3 li .list-order{width:58px;height:58px;position:relative;float:left;text-align:center;line-height:60px;background:#75b918;font-size:30px;font-weight:600;color:#FFF}ul.list-3 li .list-order:after{position:absolute;top:50%;right:0px;border:7px solid transparent;height:1px;width:0;border-right-color:#f2f2f2;margin-top:-7px;content:''}ul.list-3 li .list-content{float:left;height:58px;margin-left:8px}ul.list-3 li .list-content h5{font-size:15px;font-weight:600;margin:8px 0 4px 0}ul.popular{list-style:none;margin:0;padding:0}ul.popular li{clear:left;border-bottom:1px dotted #f1f1f1;padding:10px 0;display:block;width:100%}ul.popular li img{width:60px}ul.popular li p{margin-left:70px}ul.popular li i{color:#a1a1a1;display:block;font-style:normal;font-size:12px}ul.popular li a{font-weight:400;line-height:18px}ul.popular li a:hover{text-decoration:none;color:#464646}ul.popular li span{font-size:12px}ul.featured{list-style:none;margin:0;padding:0}ul.featured li{clear:left;border-bottom:1px dotted #f1f1f1;padding:10px 0 0 0;display:block;width:100%}ul.featured li img{width:70px}ul.featured li p{margin-left:80px}ul.featured li i{color:#a1a1a1;display:block;font-style:normal;font-size:12px}ul.featured li a{font-weight:500}ul.featured li a:hover{text-decoration:none;color:#464646}ul.featured li span{font-size:12px}ul.featured li .price{font-size:16px;font-weight:500;margin-top:5px}ul.featured li .price.discount{text-decoration:line-through;color:#e74c3c;font-size:13px;margin-right:8px}ul.recent{list-style:none;margin:0;padding:0}ul.recent li{border-bottom:1px dotted #e9e9e9}ul.recent li:last-child{border:0;padding-bottom:0}ul.recent li a{display:block;padding:10px 0}ul.recent li a:hover{border-color:#75b918}ul.recent li h6{margin:0 0 10px 0}ul.recent li h6 a{color:#353535;font-size:14px;text-transform:none;text-decoration:none;font-weight:600}ul.meta-list{margin:0;padding:10px 15px 15px 15px;display:block;list-style:none}ul.meta-list li:first-child{padding:0;border-left:0}ul.meta-list li{display:inline-block;color:#a1a1a1}ul.meta-list li a{color:#7a92ac}ul.meta-list li a:hover{color:#e06d58;text-decoration:underline}ul.bullet{list-style:none;margin:0;padding:0}ul.bullet li{clear:left;padding:10px 0;display:block;width:100%}ul.bullet li>figure{margin:5px 0 0 0;padding:0;border-radius:100%;width:35px;height:35px;background:#DDD;padding:8px 0 0;text-align:center;font-size:17px;color:#fff;font-weight:bold;display:inline-block;float:left}ul.bullet li img{width:60px}ul.bullet li h3{font-size:16px;font-weight:600;margin-left:15px;display:inline-block}ul.bullet li p{margin:0 0 0 50px;padding:0}ul.bullet li span{margin-left:6px}ul.bullet li a{font-weight:500}ul.bullet li a:hover{text-decoration:none;color:#464646}ul.bullet li span{font-size:12px}ul.list-carousel{list-style:none;margin:0;padding:0}ul.list-carousel li{padding:6px 0;display:block;width:100%;font-size:16px}ul.list-carousel li i{font-style:normal;margin-right:4px}ul.list-carousel li a{font-weight:500}ul.list-carousel li a:hover{text-decoration:none;color:#a1a1a1}ul.list-carousel li span{font-size:14px}ul.social-icons{list-style:none;margin:0;padding:0;position:absolute;bottom:0;left:0;width:100%}ul.social-icons li{display:inline-block}ul.social-icons li a{display:block;height:32px;width:32px;text-align:center;line-height:32px}ul.social-icons li:hover a{color:#fff}ul.social-icons li.text{height:32px;padding-left:10px;line-height:32px}ul.social-icons li.facebook:hover{background:#43609c;color:#fff}ul.social-icons li.twitter:hover{background:#00aced;color:#fff}ul.social-icons li.linkedin:hover{background:#517fa4;color:#fff}.table>thead>tr>th,.table>tbody>tr>th,.table>tfoot>tr>th,.table>thead>tr>td,.table>tbody>tr>td,.table>tfoot>tr>td{vertical-align:middle}.table.table-no-border>thead>tr>th,.table.table-no-border>tbody>tr>th,.table.table-no-border>tfoot>tr>th,.table.table-no-border>thead>tr>td,.table.table-no-border>tbody>tr>td,.table.table-no-border>tfoot>tr>td{border-top:0;padding:0}ul.list-listings.blog-list li{border:0}ul.list-listings.blog-list .listing-header{clear:both;padding:8px 15px;font-weight:600;text-transform:uppercase}ul.list-listings.blog-list .listing-image{width:35%;height:180px;float:left;overflow:hidden}ul.list-listings.blog-list .listing-body{width:65%;height:auto;max-height:auto;padding:0 15px;float:left;background:#fff}ul.list-listings.blog-list .listing-body h3{margin:0;padding:0;font-size:18px;font-weight:500;margin-bottom:10px}ul.list-listings.blog-list .listing-body h4{font-size:14px;font-weight:normal;line-height:22px}ul.list-listings.blog-list .listing-actions{width:15%;height:180px;position:relative;padding-top:20px;float:left;text-align:center}ul.list-listings.blog-list .listing-actions .btn{position:absolute;bottom:20px;left:25px}ul.list-listings.blog-list .list-item-info{font-size:12px;font-style:italic}.blog-masonry .w-box,.blog-grid .w-box,.blog-list .w-box{margin-bottom:25px}.w-box.blog-post{border:0;padding:0}.blog-post h2{font-size:18px;line-height:24px;color:#3b3e43;border:0;padding:25px 0px 0px 0px !important}.blog-post p{padding:8px 0px !important;font-size:14px;color:#777}.blog-post blockquote{margin:8px 0px}.blog-post .meta-list{padding-left:0 !important}.blog-post img{width:100%}.side-info{display:block}.side-info .date{display:block;text-align:center;margin-top:5px}.side-info .date strong{display:block;margin-bottom:5px;font-size:33px;font-weight:normal}.star-rating{display:block}.star-rating i{display:inline-block !important;color:#f7e90c !important}.review-rating{font-size:12px}.skills{clear:both;width:100%}.skills ul,.skills li{display:inline-block;list-style:none;margin:0 6px 0 0;padding:0}.skills li{padding:0 15px;height:35px;line-height:35px;color:#fff;margin-bottom:1px;font-size:18px}.skills .jq{background:#97BE0D}.skills .css{background:#D84F5F}.skills .html{background:#88B8E6}.skills .html{background:#BEDBE9}.skills .sql{background:#EDEBEE}.form-control{border-radius:1px;padding:8px 12px}.form-dark .form-control{margin-bottom:10px;background:#eee;border:1px solid #ccc}.form-dark label.checkbox{font-size:12px;font-weight:normal;cursor:pointer}.form-dark .form-control:focus{background:#fff;-webkit-box-shadow:none;box-shadow:none;border-color:#bbb}.form-dark .form-control:-moz-placeholder{color:#999}.form-dark .form-control::-moz-placeholder,.form-light .form-control[placeholder]{color:#999}.form-dark .form-control:-ms-input-placeholder{color:#999}.form-dark .form-control::-webkit-input-placeholder{color:#999}.form-light .form-control{margin-bottom:10px;background:#fcfcfc;border:1px solid #ccc}.form-light label.checkbox{font-size:12px;font-weight:normal;cursor:pointer}.form-light .form-control:focus{background:#fff;-webkit-box-shadow:none;box-shadow:none;border-color:#bbb}.form-light .form-control:-moz-placeholder{color:#999}.form-light .form-control::-moz-placeholder,.form-light .form-control[placeholder]{color:#999}.form-light .form-control:-ms-input-placeholder{color:#999}.form-light .form-control::-webkit-input-placeholder{color:#999}.sign-in-wr{margin-top:26px}.sign-in-wr .form-icon{display:block;width:80px;height:80px;border-radius:80px;margin:25px auto;text-align:center;line-height:80px;font-size:40px}.sign-in-wr .form-header{padding:15px;border-bottom:1px solid #f3f3f3}.sign-in-wr .form-header h2{margin:0;padding:0 !important;font-size:18px;font-weight:500}.sign-in-wr .form-body{padding:15px;background:#fff}.sign-in-wr .form-body p{padding-left:0;margin-bottom:10px}.sign-in-wr .form-footer{padding:15px 0;border-top:1px solid #f3f3f3}.social-media i{width:40px;height:40px;display:inline-block;padding:10px;margin-right:10px;margin-bottom:10px;text-align:center;font-size:18px;background:#ddd;color:#333;border-radius:2px}.social-media .facebook{background:#43609c;color:#FFF}.social-media .twitter{background:#62addb;color:#FFF}.social-media .google{background:#dd4b39;color:#FFF}.social-media i:hover{background:none;color:#a1a1a1}.form-errors{width:100%;margin-bottom:20px}.form-errors .error{display:block;color:#ce1a33;font-weight:500}.help-inline{font-size:11px;color:#B8321F;position:relative;top:-8px}#info-box{display:none;text-align:center;margin-top:30px;color:#59b540}#info-box h2{font-size:16px;font-weight:600}.map-canvas{margin-top:30px;height:300px}.map-canvas .info-window-content{min-width:250px}.map-canvas .info-window-content h2{font-size:18px;font-weight:600;margin-bottom:8px}.map-canvas .info-window-content h3{font-size:14px;font-weight:500}.map-canvas .info-window-content p{font-size:12px;color:#999;text-shadow:none}.testimonial-text{width:70%;margin:20px auto;font-size:14px;line-height:24px}.testimonial-author{display:block;text-align:center;color:#a1a1a1;font-style:italic}.contact-info{margin-bottom:20px}.contact-info h5{margin:0}.carousel-testimonials .testimonial-author-info{padding-top:28px}.carousel-testimonials .testimonial-author-info a{padding-left:20px}.client{border:1px solid #ddd;padding:0 15px;background:transparent}.client img{width:100%;-webkit-filter:grayscale(100%);-moz-filter:grayscale(100%);filter:grayscale(100%)}.client img:hover{-webkit-filter:grayscale(0);-moz-filter:grayscale(0);filter:grayscale(0)}footer{padding-top:15px;padding-bottom:20px;min-height:30px;background:#232323}footer:before,footer:after{display:table;content:" "}footer:after{clear:both}footer .col.reset{margin:0}footer h4{margin-top:20px;color:#ccc;margin-bottom:20px;text-transform:capitalize;font-size:14px}footer .col p{color:#ccc;font-size:13px;margin-bottom:10px}footer a{color:#ccc;text-decoration:none}footer a:hover{text-decoration:none}footer .col ul{margin:0;padding:0;list-style:none}footer .col ul li{color:#8F8F8F}footer .col ul li span{color:#FFF}footer .col address{color:#ddd;padding:8px 0}footer .company-info{font-size:10px;text-align:justify}footer .company-info h2{font-size:14px;font-weight:600}footer .col.col-social-icons i{width:40px;height:40px;display:inline-block;padding:10px;margin-right:10px;margin-bottom:10px;text-align:center;font-size:18px;background:#fff;color:#333;border-radius:2px}footer form{margin-top:20px}footer hr{border-top:1px solid #444}footer .copyright{color:#FFF}.fontawesome-icon-list{margin-top:22px}.fontawesome-icon-list .fa-hover a{display:block;color:#222;line-height:32px;height:32px;padding-left:10px;border-radius:0}.fontawesome-icon-list .fa-hover a .fa{width:32px;font-size:14px;display:inline-block;text-align:right;margin-right:10px}.fontawesome-icon-list .fa-hover a:hover{background-color:#1d9d74;color:#fff;text-decoration:none}.fontawesome-icon-list .fa-hover a:hover .fa{font-size:28px;vertical-align:-6px}.fontawesome-icon-list .fa-hover a:hover .text-muted{color:#bbe2d5}@media (min-width:1200px){.top-header .aux-text{display:inline-block !important}.w-section .aside-feature{text-align:left}.w-section .aside-feature .icon-feature{text-align:left}.slider{width:100%}.w-section .txt-fly-over{height:350px;top:-90px}.navbar-default .dropdown-menu,.navbar-wp .dropdown-menu{margin-top:0px !important}.navbar-default .dropdown-menu,.navbar-wp .dropdown-menu.dropdown-menu-user{margin-top:13px !important}.wrapper.boxed{width:1230px;margin:auto}}@media (min-width:992px) and (max-width:1199px){.top-header .aux-text{display:inline-block !important}.navbar-default .dropdown-menu,.navbar-wp .dropdown-menu{margin-top:0px !important}.navbar-default .dropdown-menu,.navbar-wp .dropdown-menu.dropdown-menu-user{margin-top:13px !important}.wrapper.boxed{width:1000px;margin:auto}.w-section .txt-fly-over{height:390px;top:-60px}}@media (min-width:768px) and (max-width:991px){.top-header .aux-text{display:inline-block !important}.w-box,.carousel-work .figure{margin-bottom:15px}.animate-hover-slide img{width:100%}.carousel-1 .object{width:400px !important}.slider{width:100%}.w-section .txt-fly-over{height:400px;top:-60px}.client{margin-bottom:20px}.work.work-no-space.g2 .mix{width:50%}.work.work-no-space.g3 .mix{width:50%}.work.work-no-space.g4 .mix{width:50%}.work.work-no-space.g5 .mix{width:50%}}@media (max-width:767px){header .navbar-brand{margin:14px 0}.navbar-wp .navbar-nav>li>a{color:#4c4c4c;padding:10px 20px !important;margin-right:0}.navbar-wp .navbar-nav>li>a:hover,.navbar-wp .navbar-nav>li>a:focus{color:#FFF;background-color:#e06d58;border-radius:0 !important}.navbar-wp .navbar-nav>.active>a,.navbar-wp .navbar-nav>.active>a:hover,.navbar-wp .navbar-nav>.active>a:focus{border-radius:0 !important}.navbar-wp .dropdown-menu:after{border:0 !important;margin-left:0}.navbar-wp .dropdown-menu:before{border:0 !important;margin-left:0}.top-header .top-header-menu ul.menu>li ul.sub-menu{display:none !important}.w-section .aside-feature{text-align:center}.w-section .aside-feature .icon-feature{text-align:center}.sort-list-btn .btn{margin-bottom:10px}.w-box,.carousel-work .figure{margin-bottom:15px}.animate-hover-slide .figure img{width:100%}.carousel-1 .carousel-inner{height:420px}.carousel-1 .carousel-inner{overflow:hidden}.carousel-1 .carousel-control i{position:absolute;top:50%;margin-top:-18px;font-size:36px;font-weight:600}.carousel-1 .item-dark{color:#FFF}.carousel-1 p{font-size:16px}.carousel-1 .object{display:none}.carousel-1 .object.fluid{width:100%;left:0;margin:0}.carousel-1 .object iframe{width:100% !important}.carousel-1 .description{width:100% !important;top:50px;left:0 !important;margin:0 !important}.carousel-1 .description .title{font-size:32px;margin:0 0 15px 0;padding:8px 20px;background:#FFF;color:#9ab2cc;display:block;text-align:center}.carousel-1 .description .subtitle{font-size:24px;margin:20px 0;padding:0 15px !important;display:block;text-align:center}.carousel-1 .description p{font-size:16px;color:#FFF;margin:0}.carousel-1 .description.fluid-center .features i{width:80px;height:80px;background:#FFF;text-align:center;line-height:80px;font-size:34px;color:#697e93;font-weight:700;border-radius:80px;margin-right:20px}.carousel-1 .list-carousel{padding-left:30px !important}.carousel-3 .figure{margin-bottom:20px}.slider{height:auto;max-height:440px;margin:0}.cta-wr{text-align:center}.cta-wr .btn{float:none !important}.w-section .txt-fly-over{height:400px;position:static;top:0}.client{margin-bottom:20px}.work.work-no-space.g2 .mix{width:100%}.work.work-no-space.g3 .mix{width:100%}.work.work-no-space.g4 .mix{width:100%}.work.work-no-space.g5 .mix{width:100%}}@media only screen and (min-width:1440px){.slider{width:100%}}@media (max-width:460px){.search-wr .search-sign i{margin-left:0}.global-search-input{font-size:16px;padding:14px 0}}
+/*
+Theme Name: Boomerang Bootstrap Template
+Theme URI: http://preview.webpixels.ro/boomerang/
+Description: Boomerang Bootstrap Template for corporate, digital agency, photostudio, creative, frelancers or business. Based on a unique, clean & minimal design and packed with a tons of cool features.
+Author: Alexis Enache
+Author URI: http://www.webpixels.ro
+Version: 1.2  
+License URI: http://wrapbootstrap.com        
+*/
+/* FONTS */
+@import url(//fonts.googleapis.com/css?family=PT+Sans:400,700,400italic);
+@import "//fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic";
+/* IMPORTS */
+@import url(../assets/bootstrap/css/bootstrap.min.css);
+@import url(../assets/fancybox/jquery.fancybox.css?v=2.1.5);
+@import url(../font-awesome/css/font-awesome.css);
+@import url(../assets/animate/animate.css);
+@import url(../assets/easy-pie-chart/easypiechart.css);
+@import url(../assets/timeline/timeline.css);
+/* THEMES AND SHORTCODES */
+body {
+  font-family: "PT Sans", sans-serif !important;
+  font-size: 13px;
+  line-height: 22px;
+  font-weight: 300;
+}
+body .lw {
+  color: #666;
+}
+body .ld {
+  color: #888;
+}
+.body-bg-1 {
+  background: url("../images/background/slash_it.png") repeat;
+}
+.body-bg-2 {
+  background: url("../images/background/grey_wash_wall.png") repeat;
+}
+.body-bg-3 {
+  background: url("../images/background/mooning.png") repeat;
+}
+.body-bg-4 {
+  background: url("../images/background/squairy_light.png") repeat;
+}
+.body-bg-5 {
+  background: url("../images/background/bg-img-1.jpg") no-repeat fixed;
+}
+.body-bg-6 {
+  background: url("../images/background/bg-img-2.jpg") no-repeat fixed;
+}
+.wp-theme-1 {
+  /* LAYER SLIDER CUSTOMS */
+  /* BOX ELEMENTS */
+  /* TAG CLOUD */
+}
+.wp-theme-1 .btn {
+  font-weight: normal;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+.wp-theme-1 .btn i {
+  margin-right: 4px;
+}
+.wp-theme-1 .btn-lg {
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 3px;
+}
+.wp-theme-1 .btn-lg i {
+  font-size: 24px;
+  position: relative;
+  top: 3px;
+}
+.wp-theme-1 .btn-xs {
+  padding: 4px 10px;
+}
+.wp-theme-1 .btn-one {
+  background-color: none;
+  border: 2px solid #FFF;
+  color: #FFF;
+}
+.wp-theme-1 .btn-one:hover,
+.wp-theme-1 .btn-one:focus,
+.wp-theme-1 .btn-one:active,
+.wp-theme-1 .btn-one.active,
+.wp-theme-1 .open .dropdown-toggle.btn-one {
+  color: #e91b23;
+  background-color: #FFF;
+  border-color: #FFF;
+}
+.wp-theme-1 .btn-one:active,
+.wp-theme-1 .btn-one.active,
+.wp-theme-1 .open .dropdown-toggle.btn-one {
+  background-image: none;
+}
+.wp-theme-1 .btn-two {
+  color: #ffffff;
+  background-color: #e91b23;
+  border: 1px solid;
+  border-color: #df1119;
+}
+.wp-theme-1 .btn-two:hover,
+.wp-theme-1 .btn-two:focus,
+.wp-theme-1 .btn-two:active,
+.wp-theme-1 .btn-two.active,
+.wp-theme-1 .open .dropdown-toggle.btn-two {
+  color: #ffffff;
+  background-color: #d5070f;
+  border-color: #d5070f;
+}
+.wp-theme-1 .btn-two:active,
+.wp-theme-1 .btn-two.active,
+.wp-theme-1 .open .dropdown-toggle.btn-two {
+  background-image: none;
+}
+.wp-theme-1 .btn-three {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid;
+  border-color: #292929;
+}
+.wp-theme-1 .btn-three:hover,
+.wp-theme-1 .btn-three:focus,
+.wp-theme-1 .btn-three:active,
+.wp-theme-1 .btn-three.active,
+.wp-theme-1 .open .dropdown-toggle.btn-three {
+  color: #ffffff;
+  background-color: #1f1f1f;
+  border-color: #1f1f1f;
+}
+.wp-theme-1 .btn-three:active,
+.wp-theme-1 .btn-three.active,
+.wp-theme-1 .open .dropdown-toggle.btn-three {
+  background-image: none;
+}
+.wp-theme-1 .btn-four {
+  background-color: none;
+  border: 2px solid #e91b23;
+  color: #e91b23;
+}
+.wp-theme-1 .btn-four:hover,
+.wp-theme-1 .btn-four:focus,
+.wp-theme-1 .btn-four:active,
+.wp-theme-1 .btn-four.active,
+.wp-theme-1 .open .dropdown-toggle.btn-four {
+  color: #FFF;
+  background-color: #e91b23;
+}
+.wp-theme-1 .btn-four:active,
+.wp-theme-1 .btn-four.active,
+.wp-theme-1 .open .dropdown-toggle.btn-four {
+  background-image: none;
+}
+.wp-theme-1 h1,
+.wp-theme-1 h2,
+.wp-theme-1 h3,
+.wp-theme-1 h4,
+.wp-theme-1 h5,
+.wp-theme-1 h6 {
+  font-family: "Roboto", sans-serif !important;
+}
+.wp-theme-1 p {
+  line-height: 22px;
+}
+.wp-theme-1 a {
+  color: #616161;
+  cursor: pointer;
+}
+.wp-theme-1 a:hover {
+  color: #e91b23;
+  text-decoration: none;
+  -o-transition: .3s;
+  -ms-transition: .3s;
+  -moz-transition: .3s;
+  -webkit-transition: .3s;
+  transition: .35s;
+}
+.wp-theme-1 .bg-2 {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-1 .lw .bg-5 {
+  background: #fcfcfc;
+  border-top: 1px solid #e0eded;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-1 .ld .bg-5 {
+  background: #363636;
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-1 .lw .bg-3 {
+  background: #fff;
+  color: #616161;
+}
+.wp-theme-1 .ld .bg-3 {
+  background: #202020;
+  color: #888;
+}
+.wp-theme-1 .bg-4 {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-1 .dark {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-1 .red {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-1 .orange {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-1 .green {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-1 .blue {
+  background: #3498db;
+  color: #FFF;
+}
+.wp-theme-1 .light {
+  background: #fff;
+  color: #616161 !important;
+}
+.wp-theme-1 .blockquote-1:hover {
+  border-color: #e91b23;
+}
+.wp-theme-1 .blockquote-1 p {
+  font-size: 13px;
+}
+.wp-theme-1 .section-title {
+  display: inline-block;
+  border-bottom: 1px solid #333;
+  margin: 0 0 15px 0;
+  padding: 0 0 5px 0;
+  font-size: 20px;
+  font-weight: 500;
+  text-transform: capitalize;
+  position: relative;
+  overflow: hidden;
+}
+.wp-theme-1 .lw .section-title {
+  color: #333;
+}
+.wp-theme-1 .ld .section-title {
+  color: #fff;
+}
+.wp-theme-1 .section-title.white {
+  color: #fff;
+  border-bottom: 1px solid #fff;
+}
+.wp-theme-1 .navbar-wp {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  z-index: 1000;
+}
+.wp-theme-1 .lw .navbar-wp {
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-1 .ld .navbar-wp {
+  background: #181818;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-1 .ld .sticky-wrapper .navbar-wp {
+  background: rgba(24, 24, 24, 0.85);
+  border-bottom: 1px solid #444;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > li > a {
+  padding: 28px 16px;
+  margin-right: 0;
+  font-size: 15px;
+  font-weight: normal;
+}
+.wp-theme-1 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-1 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-1 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-1 .lw .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #333;
+}
+.wp-theme-1 .lw .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-1 .lw .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #e91b23;
+}
+.wp-theme-1 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-1 .ld .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #fff;
+}
+.wp-theme-1 .ld .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-1 .ld .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #e91b23;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > .active > a,
+.wp-theme-1 .navbar-wp .navbar-nav > .active > a:hover,
+.wp-theme-1 .navbar-wp .navbar-nav > .active > a:focus {
+  color: #fff !important;
+  background-color: #e91b23;
+  border-radius: 0;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > .disabled > a,
+.wp-theme-1 .navbar-wp .navbar-nav > .disabled > a:hover,
+.wp-theme-1 .navbar-wp .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a,
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a:hover,
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a:focus {
+  color: #FFF !important;
+  background-color: #e91b23;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a .caret,
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a:hover .caret,
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle,
+.wp-theme-1 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-1 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:focus {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+  color: #e91b23;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle,
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:hover,
+.wp-theme-1 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:focus {
+  color: #e91b23 !important;
+  background-color: none;
+}
+.wp-theme-1 .navbar-wp .navbar-toggle {
+  border-color: #333;
+  margin-top: 20px;
+}
+.wp-theme-1 .navbar-wp .navbar-toggle .icon-bar {
+  background-color: #4c4c4c;
+}
+.wp-theme-1 .navbar-wp .navbar-toggle .icon-custom {
+  font-size: 18px;
+}
+.wp-theme-1 .navbar-wp .navbar-toggle:hover,
+.wp-theme-1 .navbar-wp .navbar-toggle:focus {
+  background-color: #e91b23;
+  border-color: #e91b23;
+}
+.wp-theme-1 .navbar-wp .navbar-toggle:hover .icon-bar,
+.wp-theme-1 .navbar-wp .navbar-toggle:focus .icon-bar {
+  background-color: #FFF;
+}
+.wp-theme-1 .navbar-wp .navbar-toggle:hover .icon-custom,
+.wp-theme-1 .navbar-wp .navbar-toggle:focus .icon-custom {
+  color: #FFF;
+}
+.wp-theme-1 .navbar-wp .navbar-toggle-aside-menu {
+  padding: 8px 10px 2px 10px;
+}
+.wp-theme-1 .navbar-wp .navbar-collapse,
+.wp-theme-1 .navbar-wp .navbar-form {
+  border-color: #e7e7e7;
+}
+.wp-theme-1 .navbar-wp .navbar-nav > .dropdown > a:hover .caret,
+.wp-theme-1 .navbar-wp .navbar-nav > .dropdown > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu {
+  min-width: 220px;
+  background: #FFF;
+  border: 0;
+  border-top: 1px solid #e91b23;
+  border-bottom: 3px solid #e91b23;
+  border-radius: 0;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu > li {
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu > li:last-child {
+  border: 0;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu > li > a {
+  color: #333;
+  padding: 8px 15px;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu > li > a:hover {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu label.checkbox {
+  color: #333;
+}
+.wp-theme-1 .navbar-wp .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu-user {
+  border: 1px solid #e0eded;
+  border-top-color: transparent;
+}
+.wp-theme-1 .navbar-wp .dropdown-menu-user {
+  background: #fff;
+}
+.wp-theme-1 .navbar-wp .navbar-right .dropdown-menu-user {
+  background: #fff;
+  border-color: transparent;
+}
+.wp-theme-1 .navbar-wp .navbar-right .social-link {
+  width: 40px;
+  height: 40px;
+  line-height: 20px;
+  text-align: center;
+  padding: 10px;
+  margin: 18px 0;
+  border-radius: 100%;
+}
+.wp-theme-1 .navbar-wp .navbar-right .social-link.facebook:hover {
+  background: #43609c;
+  color: #fff;
+}
+.wp-theme-1 .navbar-wp .navbar-right .social-link.pinterest:hover {
+  background: #cb2027;
+  color: #fff;
+}
+.wp-theme-1 .navbar-wp .navbar-right .social-link.twitter:hover {
+  background: #62addb;
+  color: #fff;
+}
+.wp-theme-1 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-1 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-1 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-1 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > .open > a,
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover,
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus {
+  color: #FFF;
+  background-color: #2c2c2c;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > .open > a .caret,
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover .caret,
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:focus {
+  background: none;
+  color: #e91b23;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  bottom: 100%;
+  right: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-right: -35px;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  bottom: 100%;
+  left: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-left: -35px;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu {
+  min-width: 220px;
+  background: #2c2c2c;
+  border: 0;
+  border-top: 0;
+  border-bottom: 0;
+  border-radius: 0;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu > li {
+  border-bottom: 1px solid #262626;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu > li > a {
+  color: #fff;
+  padding: 8px 15px;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu > li > a:hover {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox {
+  color: #fff;
+}
+.wp-theme-1 .navbar-wp.navbar-contrasted .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-1 .dropdown-submenu {
+  position: relative;
+}
+.wp-theme-1 .dropdown-submenu > .dropdown-menu {
+  top: -5px;
+  left: 100%;
+  margin-top: 0;
+  margin-left: -1px;
+}
+.wp-theme-1 .dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+.wp-theme-1 .dropdown-submenu > a:after {
+  display: block;
+  content: " ";
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 3px 0 3px 3px;
+  border-left-color: #ccc;
+  margin-top: 5px;
+  margin-right: -6px;
+}
+.wp-theme-1 .dropdown-submenu:hover > a:after {
+  border-left-color: #fff;
+}
+.wp-theme-1 .dropdown-submenu.pull-left {
+  float: none;
+}
+.wp-theme-1 .dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+}
+.wp-theme-1 .nav > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-1 .nav > ul > li {
+  border-bottom: 1px solid #333;
+}
+.wp-theme-1 .nav > ul > li > a {
+  display: block;
+  padding: 10px 15px;
+  font-size: 14px;
+  color: #fff;
+}
+.wp-theme-1 .nav > ul > li > a:hover {
+  text-decoration: none;
+  color: #e91b23;
+  background: #292929;
+}
+.wp-theme-1 .nav > ul > li > a > i {
+  margin-right: 5px;
+}
+.wp-theme-1 .lw .pg-opt {
+  border-bottom: 1px solid #e0eded;
+  background: #fcfcfc;
+}
+.wp-theme-1 .ld .pg-opt {
+  border-bottom: 1px solid #444;
+  background: #111;
+}
+.wp-theme-1 .pg-opt.fixed {
+  width: 100%;
+  position: fixed;
+  top: 0px;
+  background: rgba(250, 250, 250, 0.9);
+  border-bottom: 1px solid #e0eded;
+  z-index: 900;
+}
+.wp-theme-1 .pg-opt h2 {
+  margin: 0;
+  padding: 14px 0;
+  font-size: 22px;
+  line-height: 100%;
+}
+.wp-theme-1 .pg-opt.fixed h2 {
+  margin-bottom: 15px;
+}
+.wp-theme-1 .pg-opt hr {
+  margin: 0;
+  border-top-color: #dde1e6;
+  -webkit-box-shadow: 0 1px 0 #fbfbfc;
+  -moz-box-shadow: 0 1px 0 #fbfbfc;
+  box-shadow: 0 1px 0 #fbfbfc;
+}
+.wp-theme-1 .pg-opt.fixed hr {
+  display: none;
+}
+.wp-theme-1 .pg-opt .breadcrumb {
+  float: right;
+  margin: 0;
+  padding: 16px 0;
+  background: none;
+  border-radius: 0;
+}
+.wp-theme-1 .pg-opt .breadcrumb a {
+  color: #e91b23;
+}
+@media only screen and (max-width: 767px) {
+  .wp-theme-1 .pg-opt .pg-nav {
+    float: left;
+    margin-bottom: 10px;
+  }
+  .wp-theme-1 .pg-opt h2 {
+    padding: 20px 0 0 0;
+  }
+}
+.wp-theme-1 .page-header {
+  margin: 0;
+  border: 0;
+}
+.wp-theme-1 .page-header p {
+  font-size: 16px;
+}
+.wp-theme-1 .w-box {
+  margin: 0 0 15px 0;
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+  border: 1px solid #e0eded;
+}
+.wp-theme-1 .w-box:before,
+.wp-theme-1 .w-box:after {
+  display: table;
+  content: "";
+}
+.wp-theme-1 .w-box:after {
+  clear: both;
+}
+.wp-theme-1 .w-box h1 {
+  margin: 0;
+  padding: 10px 15px;
+  font-weight: 500;
+  font-size: 20px;
+}
+.wp-theme-1 .lw .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #333;
+}
+.wp-theme-1 .ld .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #fff;
+}
+.wp-theme-1 .w-box.inner h2 {
+  padding: 10px 0;
+}
+.wp-theme-1 .w-box small {
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+.wp-theme-1 .w-box p {
+  margin: 6px 0;
+  padding: 0 15px;
+  padding-bottom: 8px;
+}
+.wp-theme-1 .w-box time {
+  display: block;
+  padding: 8px 15px 0 15px;
+}
+.wp-theme-1 .w-box .w-footer {
+  padding: 10px 15px;
+  border-top: 1px solid #f1f1f1;
+}
+.wp-theme-1 .w-box .w-footer:before,
+.wp-theme-1 .w-box .w-footer:after {
+  display: table;
+  content: "";
+}
+.wp-theme-1 .w-box .w-footer:after {
+  clear: both;
+}
+.wp-theme-1 .w-box .w-footer small {
+  font-size: 12px;
+}
+.wp-theme-1 .w-box .w-box-parent {
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+}
+.wp-theme-1 .w-box .date-over {
+  padding: 10px;
+  background: #ffffff;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  text-align: center;
+  font-weight: normal;
+}
+.wp-theme-1 .w-box .date-over.small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.wp-theme-1 .w-box .date-over strong {
+  font-size: 12px;
+  display: block;
+  font-weight: normal;
+}
+.wp-theme-1 .w-box.dark {
+  background: #333;
+}
+.wp-theme-1 .w-box.dark h2 {
+  color: #fff;
+}
+.wp-theme-1 .w-box.white h2 {
+  border-bottom: 0;
+  text-align: center;
+}
+.wp-theme-1 .w-box.white .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.wp-theme-1 .lw .w-box.white {
+  background: #FFF;
+}
+.wp-theme-1 .lw .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-1 .ld .w-box.white {
+  background: #202020;
+  border: 1px solid #444;
+}
+.wp-theme-1 .ld .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-1 .w-box.w-box-inverse .thmb-img i {
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  font-size: 34px;
+  line-height: 100px;
+  text-align: center;
+}
+.wp-theme-1 .lw .w-box.w-box-inverse .thmb-img i {
+  background: #fcfcfc;
+  color: #e91b23;
+}
+.wp-theme-1 .ld .w-box.w-box-inverse .thmb-img i {
+  background: #363636;
+  color: #fff;
+}
+.wp-theme-1 .w-box.w-box-inverse .thmb-img:hover i {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-1 .c-box {
+  border: 1px solid #e91b23;
+}
+.wp-theme-1 .c-box .c-box-header {
+  padding: 10px 15px;
+  background: #e91b23;
+  color: #fff;
+  font-size: 16px;
+  text-transform: capitalize;
+}
+.wp-theme-1 .c-box .table {
+  margin: 0;
+}
+.wp-theme-1 .ld .w-section h4,
+.wp-theme-1 .ld .w-section h3,
+.wp-theme-1 .ld .w-section h2 {
+  color: #fff;
+}
+.wp-theme-1 .w-section .aside-feature {
+  margin: 10px;
+  cursor: default;
+}
+.wp-theme-1 .w-section .aside-feature .icon-feature {
+  font-size: 68px;
+  margin-top: 10px;
+  text-align: center;
+  display: block;
+}
+.wp-theme-1 .w-section .aside-feature:hover .icon-feature,
+.wp-theme-1 .w-section .aside-feature:hover h4 {
+  color: #e91b23;
+}
+.wp-theme-1 .w-section .aside-feature .img-feature {
+  margin-top: 4px;
+  display: block;
+}
+.wp-theme-1 .w-section .aside-feature .img-feature img {
+  width: 78px;
+}
+.wp-theme-1 .layer-slider-wrapper {
+  max-height: 500px;
+  overflow: hidden;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-1 .layer-slider-wrapper .title {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-1 .layer-slider-wrapper .title.title-base {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #FFF;
+  background: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-1 .layer-slider-wrapper .title.title-dark {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-1 .layer-slider-wrapper .subtitle {
+  font-size: 22px;
+  line-height: 30px;
+  color: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-1 .layer-slider-wrapper .list-item {
+  font-size: 18px;
+  line-height: 30px;
+  padding-left: 30px;
+  color: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-1 .layer-slider-wrapper .text-standard {
+  font-size: 16px;
+  line-height: 22px;
+}
+.wp-theme-1 .box-element {
+  padding: 20px;
+}
+.wp-theme-1 .box-element:nth-child(n+1) {
+  margin-top: 20px;
+}
+.wp-theme-1 .box-element h1 {
+  margin: 10px 0 !important;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 400;
+}
+.wp-theme-1 .box-element.box-element-bordered {
+  background: transparent !important;
+  border: 1px solid #e91b23;
+}
+.wp-theme-1 .box-element.box-element-outer {
+  padding-left: 0;
+  padding-right: 0;
+}
+.wp-theme-1 .pricing-plans .plan-header .popular-tag {
+  background: #333;
+  border-bottom: 1px solid #FFF;
+  color: #fff;
+}
+.wp-theme-1 .carousel-2 {
+  position: relative;
+}
+.wp-theme-1 .carousel-2 .item {
+  padding: 36px 0 !important;
+}
+.wp-theme-1 .carousel-2 .carousel-indicators {
+  bottom: 0;
+}
+.wp-theme-1 .carousel-2 .carousel-indicators li {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+}
+.wp-theme-1 .carousel-2 .carousel-indicators .active {
+  background-color: #e91b23;
+}
+.wp-theme-1 .carousel-2 .img-thumbnail {
+  margin-top: 26px;
+}
+.wp-theme-1 .carousel-2 h2 {
+  font-size: 22px;
+}
+.wp-theme-1 .carousel-2 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: 10px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #e91b23;
+  opacity: 1;
+}
+.wp-theme-1 .carousel-2 .carousel-nav a:hover {
+  background: #e91b23 !important;
+  color: #fff;
+}
+.wp-theme-1 .carousel-2 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-1 .carousel-2 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-1 .carousel-2 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  font-size: 22px;
+  margin-top: -11px;
+}
+.wp-theme-1 .carousel-2 .carousel-control.left i {
+  left: 18px;
+}
+.wp-theme-1 .carousel-2 .carousel-control.right i {
+  right: 18px;
+}
+.wp-theme-1 .carousel-3 {
+  position: relative;
+}
+.wp-theme-1 .carousel-3 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: -50px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #e91b23;
+  opacity: 1;
+}
+.wp-theme-1 .carousel-3 .carousel-nav a:hover {
+  background: #e91b23 !important;
+  color: #fff;
+}
+.wp-theme-1 .carousel-3 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-1 .carousel-3 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-1 .carousel-3 .carousel-nav a:hover {
+  background: #FFF;
+}
+.wp-theme-1 .carousel-testimonials {
+  position: relative;
+  border: 1px solid #e0eded;
+}
+.wp-theme-1 .like-button .button {
+  display: block;
+  text-align: right;
+  padding-top: 10px;
+  color: #ddd;
+}
+.wp-theme-1 .like-button .button i {
+  font-size: 20px;
+  color: #ddd;
+}
+.wp-theme-1 .like-button .button.liked i {
+  color: #e91b23;
+}
+.wp-theme-1 .like-button .count {
+  display: block;
+  text-align: right;
+  position: relative;
+  top: -7px;
+}
+.wp-theme-1 .like-button.inline .button {
+  display: inline-block;
+  padding: 0;
+}
+.wp-theme-1 .like-button.inline .count {
+  display: inline-block;
+  top: -2px;
+}
+.wp-theme-1 .like-button.inline .count small {
+  font-size: 13px;
+}
+.wp-theme-1 .side-like-box {
+  text-align: center;
+  padding: 5px 5px 0 5px;
+  margin-top: 10px;
+}
+.wp-theme-1 .side-like-box .button {
+  text-align: center;
+  padding: 0;
+}
+.wp-theme-1 .side-like-box .count {
+  text-align: center;
+}
+.wp-theme-1 .side-like-box i {
+  font-size: 24px;
+}
+.wp-theme-1 ul.list-listings {
+  margin: 0 0 20px 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-1 ul.list-listings li {
+  margin-bottom: 30px;
+  border: 1px solid #f3f3f3;
+  overflow: hidden;
+}
+.wp-theme-1 ul.list-listings li.featured {
+  border-color: #e91b23;
+}
+.wp-theme-1 ul.list-listings li:before,
+.wp-theme-1 ul.list-listings li:after {
+  content: "";
+  display: table;
+}
+.wp-theme-1 ul.list-listings li:after {
+  clear: both;
+}
+.wp-theme-1 ul.list-listings .listing-header {
+  clear: both;
+  padding: 8px 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.wp-theme-1 ul.list-listings .listing-image {
+  width: 25%;
+  height: 150px;
+  float: left;
+  overflow: hidden;
+}
+.wp-theme-1 ul.list-listings .listing-body {
+  width: 50%;
+  height: 150px;
+  padding: 15px;
+  float: left;
+  background: #fcfcfc;
+  border-right: 1px solid #fcfcfc;
+}
+.wp-theme-1 ul.list-listings .listing-body h3 {
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 25px;
+}
+.wp-theme-1 ul.list-listings .listing-body h4 {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 22px;
+}
+.wp-theme-1 ul.list-listings .listing-actions {
+  width: 25%;
+  height: 110px;
+  padding-top: 40px;
+  float: left;
+  text-align: center;
+}
+.wp-theme-1 ul.list-listings .listing-actions .btn {
+  margin-top: 6px;
+}
+.wp-theme-1 ul.list-check {
+  list-style: none;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+}
+.wp-theme-1 ul.list-check li {
+  padding: 4px 0;
+  margin: 0;
+  display: block;
+  width: 100%;
+}
+.wp-theme-1 ul.list-check li i {
+  color: #e91b23;
+  font-style: normal;
+  margin-right: 4px;
+}
+.wp-theme-1 ul.list-check li span {
+  font-size: 14px;
+}
+.wp-theme-1 ul.categories {
+  list-style: none;
+  margin: 0;
+  padding: 0 !important;
+  border: 1px solid #e0eded;
+  overflow: hidden;
+}
+.wp-theme-1 ul.categories li {
+  border-bottom: 1px solid #e0eded;
+  position: reltive;
+}
+.wp-theme-1 ul.categories li:last-child {
+  border: 0;
+}
+.wp-theme-1 ul.categories li a {
+  display: block;
+  padding: 10px 15px;
+}
+.wp-theme-1 ul.categories li a:after {
+  font-family: 'FontAwesome';
+  content: "\f105";
+  position: relative;
+  top: 0;
+  float: right;
+}
+.wp-theme-1 ul.categories li a:hover {
+  background: #e91b23;
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-1 ul.categories li a i {
+  display: inline-block;
+  vertical-align: middle;
+  padding-right: 5px;
+  font-style: normal;
+  color: #999;
+  font-size: 11px;
+}
+.wp-theme-1 ul.categories li a:hover i {
+  color: #FFF;
+}
+.wp-theme-1 .timeline .year {
+  width: 100%;
+  background: #333;
+  padding: 8px 10px;
+  margin: 20px auto 40px !important;
+  font-size: 20px;
+}
+.wp-theme-1 .timeline .year {
+  border-radius: 3px;
+}
+.wp-theme-1 .timeline .event {
+  padding: 0;
+  border: 1px solid #e0eded;
+  border-radius: 0;
+}
+.wp-theme-1 .timeline .event:nth-child(2n):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -6.8% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #e91b23;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-1 .timeline .event:nth-child(2n-1):after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #FFF;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+}
+.wp-theme-1 .timeline .event:nth-child(2n-1):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -6.5% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #e91b23;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-1 .timeline .event-date {
+  margin: 0;
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+  text-align: left;
+  padding: 10px 10px;
+  font-weight: 500;
+  font-size: 14px;
+}
+.wp-theme-1 .timeline .event:nth-child(2n) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-1 .timeline .event:nth-child(2n) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  right: -13px;
+  width: 0;
+  height: 0;
+  border-left: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-1 .timeline .event:nth-child(2n-1) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-1 .timeline .event:nth-child(2n-1) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  left: -13px;
+  width: 0;
+  height: 0;
+  border-right: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-1 .timeline .event-date small {
+  display: block;
+  font-size: 12px;
+  color: #a1a1a1;
+  font-weight: normal;
+}
+.wp-theme-1 .timeline .event-date i {
+  margin-right: 7px;
+}
+.wp-theme-1 .timeline .event-body {
+  background: #f8f8f8;
+}
+.wp-theme-1 .timeline .event-footer {
+  margin: 0;
+  text-align: left;
+  padding: 8px 10px;
+  background: none;
+  border-top: 1px solid #e0eded;
+}
+.wp-theme-1 .timeline .event-footer:after,
+.wp-theme-1 .timeline .event-footer:before {
+  display: table;
+  content: " ";
+}
+.wp-theme-1 .timeline .event-footer:after {
+  clear: both;
+}
+.wp-theme-1 .timeline .event img {
+  margin: 0;
+}
+.wp-theme-1 .timeline p {
+  padding: 20px 10px;
+  text-align: left;
+}
+.wp-theme-1 .timeline iframe {
+  margin: 10px 0 0 0;
+}
+.wp-theme-1 #toTop {
+  display: none;
+  text-decoration: none;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+  border: none;
+  text-indent: 100%;
+  background: #555;
+  border-radius: 3px;
+}
+.wp-theme-1 #toTopHover {
+  background: #e91b23;
+  width: 40px;
+  height: 40px;
+  display: block;
+  overflow: hidden;
+  float: left;
+  opacity: 0;
+  -moz-opacity: 0;
+  filter: alpha(opacity=0);
+}
+.wp-theme-1 #toTop:active,
+.wp-theme-1 #toTop:focus {
+  outline: none;
+}
+.wp-theme-1 #toTop:before {
+  font-family: 'FontAwesome';
+  content: "\f106";
+  color: #ffffff;
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  line-height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  text-indent: 0;
+}
+.wp-theme-1 .widget.tags-wr {
+  padding-bottom: 15px;
+}
+.wp-theme-1 .tags-list:before,
+.wp-theme-1 .tags-list:after {
+  display: table;
+  content: "";
+}
+.wp-theme-1 .tags-list:after {
+  clear: both;
+}
+.wp-theme-1 .tags-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.wp-theme-1 .tags-list li {
+  border: 1px solid #e91b23;
+  background: #FFF;
+  padding: 5px;
+  float: left;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  color: #e91b23;
+  font-size: 12px;
+}
+.wp-theme-1 .tags-list li a {
+  color: #e91b23;
+  margin-left: 4px;
+}
+.wp-theme-1 .tags-list li:hover {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-1 .tags-list li:hover a {
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-2 {
+  /* LAYER SLIDER CUSTOMS */
+  /* BOX ELEMENTS */
+  /* TAG CLOUD */
+}
+.wp-theme-2 .btn {
+  font-weight: normal;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+.wp-theme-2 .btn i {
+  margin-right: 4px;
+}
+.wp-theme-2 .btn-lg {
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 3px;
+}
+.wp-theme-2 .btn-lg i {
+  font-size: 24px;
+  position: relative;
+  top: 3px;
+}
+.wp-theme-2 .btn-xs {
+  padding: 4px 10px;
+}
+.wp-theme-2 .btn-one {
+  background-color: none;
+  border: 2px solid #FFF;
+  color: #FFF;
+}
+.wp-theme-2 .btn-one:hover,
+.wp-theme-2 .btn-one:focus,
+.wp-theme-2 .btn-one:active,
+.wp-theme-2 .btn-one.active,
+.wp-theme-2 .open .dropdown-toggle.btn-one {
+  color: #563d7c;
+  background-color: #FFF;
+  border-color: #FFF;
+}
+.wp-theme-2 .btn-one:active,
+.wp-theme-2 .btn-one.active,
+.wp-theme-2 .open .dropdown-toggle.btn-one {
+  background-image: none;
+}
+.wp-theme-2 .btn-two {
+  color: #ffffff;
+  background-color: #563d7c;
+  border: 1px solid;
+  border-color: #4c3372;
+}
+.wp-theme-2 .btn-two:hover,
+.wp-theme-2 .btn-two:focus,
+.wp-theme-2 .btn-two:active,
+.wp-theme-2 .btn-two.active,
+.wp-theme-2 .open .dropdown-toggle.btn-two {
+  color: #ffffff;
+  background-color: #422968;
+  border-color: #422968;
+}
+.wp-theme-2 .btn-two:active,
+.wp-theme-2 .btn-two.active,
+.wp-theme-2 .open .dropdown-toggle.btn-two {
+  background-image: none;
+}
+.wp-theme-2 .btn-three {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid;
+  border-color: #292929;
+}
+.wp-theme-2 .btn-three:hover,
+.wp-theme-2 .btn-three:focus,
+.wp-theme-2 .btn-three:active,
+.wp-theme-2 .btn-three.active,
+.wp-theme-2 .open .dropdown-toggle.btn-three {
+  color: #ffffff;
+  background-color: #1f1f1f;
+  border-color: #1f1f1f;
+}
+.wp-theme-2 .btn-three:active,
+.wp-theme-2 .btn-three.active,
+.wp-theme-2 .open .dropdown-toggle.btn-three {
+  background-image: none;
+}
+.wp-theme-2 .btn-four {
+  background-color: none;
+  border: 2px solid #563d7c;
+  color: #563d7c;
+}
+.wp-theme-2 .btn-four:hover,
+.wp-theme-2 .btn-four:focus,
+.wp-theme-2 .btn-four:active,
+.wp-theme-2 .btn-four.active,
+.wp-theme-2 .open .dropdown-toggle.btn-four {
+  color: #FFF;
+  background-color: #563d7c;
+}
+.wp-theme-2 .btn-four:active,
+.wp-theme-2 .btn-four.active,
+.wp-theme-2 .open .dropdown-toggle.btn-four {
+  background-image: none;
+}
+.wp-theme-2 h1,
+.wp-theme-2 h2,
+.wp-theme-2 h3,
+.wp-theme-2 h4,
+.wp-theme-2 h5,
+.wp-theme-2 h6 {
+  font-family: "Roboto", sans-serif !important;
+}
+.wp-theme-2 p {
+  line-height: 22px;
+}
+.wp-theme-2 a {
+  color: #616161;
+  cursor: pointer;
+}
+.wp-theme-2 a:hover {
+  color: #563d7c;
+  text-decoration: none;
+  -o-transition: .3s;
+  -ms-transition: .3s;
+  -moz-transition: .3s;
+  -webkit-transition: .3s;
+  transition: .35s;
+}
+.wp-theme-2 .bg-2 {
+  background: #563d7c;
+  color: #FFF;
+}
+.wp-theme-2 .lw .bg-5 {
+  background: #fcfcfc;
+  border-top: 1px solid #e0eded;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-2 .ld .bg-5 {
+  background: #363636;
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-2 .lw .bg-3 {
+  background: #fff;
+  color: #616161;
+}
+.wp-theme-2 .ld .bg-3 {
+  background: #202020;
+  color: #888;
+}
+.wp-theme-2 .bg-4 {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-2 .dark {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-2 .red {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-2 .orange {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-2 .green {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-2 .blue {
+  background: #3498db;
+  color: #FFF;
+}
+.wp-theme-2 .light {
+  background: #fff;
+  color: #616161 !important;
+}
+.wp-theme-2 .blockquote-1:hover {
+  border-color: #563d7c;
+}
+.wp-theme-2 .blockquote-1 p {
+  font-size: 13px;
+}
+.wp-theme-2 .section-title {
+  display: inline-block;
+  border-bottom: 1px solid #333;
+  margin: 0 0 15px 0;
+  padding: 0 0 5px 0;
+  font-size: 20px;
+  font-weight: 500;
+  text-transform: capitalize;
+  position: relative;
+  overflow: hidden;
+}
+.wp-theme-2 .lw .section-title {
+  color: #333;
+}
+.wp-theme-2 .ld .section-title {
+  color: #fff;
+}
+.wp-theme-2 .section-title.white {
+  color: #fff;
+  border-bottom: 1px solid #fff;
+}
+.wp-theme-2 .navbar-wp {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  z-index: 1000;
+}
+.wp-theme-2 .lw .navbar-wp {
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-2 .ld .navbar-wp {
+  background: #181818;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-2 .ld .sticky-wrapper .navbar-wp {
+  background: rgba(24, 24, 24, 0.85);
+  border-bottom: 1px solid #444;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > li > a {
+  padding: 28px 16px;
+  margin-right: 0;
+  font-size: 15px;
+  font-weight: normal;
+}
+.wp-theme-2 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-2 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-2 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-2 .lw .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #333;
+}
+.wp-theme-2 .lw .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-2 .lw .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #563d7c;
+}
+.wp-theme-2 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-2 .ld .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #fff;
+}
+.wp-theme-2 .ld .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-2 .ld .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #563d7c;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > .active > a,
+.wp-theme-2 .navbar-wp .navbar-nav > .active > a:hover,
+.wp-theme-2 .navbar-wp .navbar-nav > .active > a:focus {
+  color: #fff !important;
+  background-color: #563d7c;
+  border-radius: 0;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > .disabled > a,
+.wp-theme-2 .navbar-wp .navbar-nav > .disabled > a:hover,
+.wp-theme-2 .navbar-wp .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a,
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a:hover,
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a:focus {
+  color: #FFF !important;
+  background-color: #563d7c;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a .caret,
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a:hover .caret,
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle,
+.wp-theme-2 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-2 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:focus {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+  color: #563d7c;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle,
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:hover,
+.wp-theme-2 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:focus {
+  color: #563d7c !important;
+  background-color: none;
+}
+.wp-theme-2 .navbar-wp .navbar-toggle {
+  border-color: #333;
+  margin-top: 20px;
+}
+.wp-theme-2 .navbar-wp .navbar-toggle .icon-bar {
+  background-color: #4c4c4c;
+}
+.wp-theme-2 .navbar-wp .navbar-toggle .icon-custom {
+  font-size: 18px;
+}
+.wp-theme-2 .navbar-wp .navbar-toggle:hover,
+.wp-theme-2 .navbar-wp .navbar-toggle:focus {
+  background-color: #563d7c;
+  border-color: #563d7c;
+}
+.wp-theme-2 .navbar-wp .navbar-toggle:hover .icon-bar,
+.wp-theme-2 .navbar-wp .navbar-toggle:focus .icon-bar {
+  background-color: #FFF;
+}
+.wp-theme-2 .navbar-wp .navbar-toggle:hover .icon-custom,
+.wp-theme-2 .navbar-wp .navbar-toggle:focus .icon-custom {
+  color: #FFF;
+}
+.wp-theme-2 .navbar-wp .navbar-toggle-aside-menu {
+  padding: 8px 10px 2px 10px;
+}
+.wp-theme-2 .navbar-wp .navbar-collapse,
+.wp-theme-2 .navbar-wp .navbar-form {
+  border-color: #e7e7e7;
+}
+.wp-theme-2 .navbar-wp .navbar-nav > .dropdown > a:hover .caret,
+.wp-theme-2 .navbar-wp .navbar-nav > .dropdown > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu {
+  min-width: 220px;
+  background: #FFF;
+  border: 0;
+  border-top: 1px solid #563d7c;
+  border-bottom: 3px solid #563d7c;
+  border-radius: 0;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu > li {
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu > li:last-child {
+  border: 0;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu > li > a {
+  color: #333;
+  padding: 8px 15px;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu > li > a:hover {
+  background: #563d7c;
+  color: #FFF;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu label.checkbox {
+  color: #333;
+}
+.wp-theme-2 .navbar-wp .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu-user {
+  border: 1px solid #e0eded;
+  border-top-color: transparent;
+}
+.wp-theme-2 .navbar-wp .dropdown-menu-user {
+  background: #fff;
+}
+.wp-theme-2 .navbar-wp .navbar-right .dropdown-menu-user {
+  background: #fff;
+  border-color: transparent;
+}
+.wp-theme-2 .navbar-wp .navbar-right .social-link {
+  width: 40px;
+  height: 40px;
+  line-height: 20px;
+  text-align: center;
+  padding: 10px;
+  margin: 18px 0;
+  border-radius: 100%;
+}
+.wp-theme-2 .navbar-wp .navbar-right .social-link.facebook:hover {
+  background: #43609c;
+  color: #fff;
+}
+.wp-theme-2 .navbar-wp .navbar-right .social-link.pinterest:hover {
+  background: #cb2027;
+  color: #fff;
+}
+.wp-theme-2 .navbar-wp .navbar-right .social-link.twitter:hover {
+  background: #62addb;
+  color: #fff;
+}
+.wp-theme-2 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-2 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-2 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-2 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > .open > a,
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover,
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus {
+  color: #FFF;
+  background-color: #2c2c2c;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > .open > a .caret,
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover .caret,
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:focus {
+  background: none;
+  color: #563d7c;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  bottom: 100%;
+  right: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-right: -35px;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  bottom: 100%;
+  left: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-left: -35px;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu {
+  min-width: 220px;
+  background: #2c2c2c;
+  border: 0;
+  border-top: 0;
+  border-bottom: 0;
+  border-radius: 0;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu > li {
+  border-bottom: 1px solid #262626;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu > li > a {
+  color: #fff;
+  padding: 8px 15px;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu > li > a:hover {
+  background: #563d7c;
+  color: #FFF;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox {
+  color: #fff;
+}
+.wp-theme-2 .navbar-wp.navbar-contrasted .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-2 .dropdown-submenu {
+  position: relative;
+}
+.wp-theme-2 .dropdown-submenu > .dropdown-menu {
+  top: -5px;
+  left: 100%;
+  margin-top: 0;
+  margin-left: -1px;
+}
+.wp-theme-2 .dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+.wp-theme-2 .dropdown-submenu > a:after {
+  display: block;
+  content: " ";
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 3px 0 3px 3px;
+  border-left-color: #ccc;
+  margin-top: 5px;
+  margin-right: -6px;
+}
+.wp-theme-2 .dropdown-submenu:hover > a:after {
+  border-left-color: #fff;
+}
+.wp-theme-2 .dropdown-submenu.pull-left {
+  float: none;
+}
+.wp-theme-2 .dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+}
+.wp-theme-2 .nav > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-2 .nav > ul > li {
+  border-bottom: 1px solid #333;
+}
+.wp-theme-2 .nav > ul > li > a {
+  display: block;
+  padding: 10px 15px;
+  font-size: 14px;
+  color: #fff;
+}
+.wp-theme-2 .nav > ul > li > a:hover {
+  text-decoration: none;
+  color: #563d7c;
+  background: #292929;
+}
+.wp-theme-2 .nav > ul > li > a > i {
+  margin-right: 5px;
+}
+.wp-theme-2 .lw .pg-opt {
+  border-bottom: 1px solid #e0eded;
+  background: #fcfcfc;
+}
+.wp-theme-2 .ld .pg-opt {
+  border-bottom: 1px solid #444;
+  background: #111;
+}
+.wp-theme-2 .pg-opt.fixed {
+  width: 100%;
+  position: fixed;
+  top: 0px;
+  background: rgba(250, 250, 250, 0.9);
+  border-bottom: 1px solid #e0eded;
+  z-index: 900;
+}
+.wp-theme-2 .pg-opt h2 {
+  margin: 0;
+  padding: 14px 0;
+  font-size: 22px;
+  line-height: 100%;
+}
+.wp-theme-2 .pg-opt.fixed h2 {
+  margin-bottom: 15px;
+}
+.wp-theme-2 .pg-opt hr {
+  margin: 0;
+  border-top-color: #dde1e6;
+  -webkit-box-shadow: 0 1px 0 #fbfbfc;
+  -moz-box-shadow: 0 1px 0 #fbfbfc;
+  box-shadow: 0 1px 0 #fbfbfc;
+}
+.wp-theme-2 .pg-opt.fixed hr {
+  display: none;
+}
+.wp-theme-2 .pg-opt .breadcrumb {
+  float: right;
+  margin: 0;
+  padding: 16px 0;
+  background: none;
+  border-radius: 0;
+}
+.wp-theme-2 .pg-opt .breadcrumb a {
+  color: #563d7c;
+}
+@media only screen and (max-width: 767px) {
+  .wp-theme-2 .pg-opt .pg-nav {
+    float: left;
+    margin-bottom: 10px;
+  }
+  .wp-theme-2 .pg-opt h2 {
+    padding: 20px 0 0 0;
+  }
+}
+.wp-theme-2 .page-header {
+  margin: 0;
+  border: 0;
+}
+.wp-theme-2 .page-header p {
+  font-size: 16px;
+}
+.wp-theme-2 .w-box {
+  margin: 0 0 15px 0;
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+  border: 1px solid #e0eded;
+}
+.wp-theme-2 .w-box:before,
+.wp-theme-2 .w-box:after {
+  display: table;
+  content: "";
+}
+.wp-theme-2 .w-box:after {
+  clear: both;
+}
+.wp-theme-2 .w-box h1 {
+  margin: 0;
+  padding: 10px 15px;
+  font-weight: 500;
+  font-size: 20px;
+}
+.wp-theme-2 .lw .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #333;
+}
+.wp-theme-2 .ld .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #fff;
+}
+.wp-theme-2 .w-box.inner h2 {
+  padding: 10px 0;
+}
+.wp-theme-2 .w-box small {
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+.wp-theme-2 .w-box p {
+  margin: 6px 0;
+  padding: 0 15px;
+  padding-bottom: 8px;
+}
+.wp-theme-2 .w-box time {
+  display: block;
+  padding: 8px 15px 0 15px;
+}
+.wp-theme-2 .w-box .w-footer {
+  padding: 10px 15px;
+  border-top: 1px solid #f1f1f1;
+}
+.wp-theme-2 .w-box .w-footer:before,
+.wp-theme-2 .w-box .w-footer:after {
+  display: table;
+  content: "";
+}
+.wp-theme-2 .w-box .w-footer:after {
+  clear: both;
+}
+.wp-theme-2 .w-box .w-footer small {
+  font-size: 12px;
+}
+.wp-theme-2 .w-box .w-box-parent {
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+}
+.wp-theme-2 .w-box .date-over {
+  padding: 10px;
+  background: #ffffff;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  text-align: center;
+  font-weight: normal;
+}
+.wp-theme-2 .w-box .date-over.small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.wp-theme-2 .w-box .date-over strong {
+  font-size: 12px;
+  display: block;
+  font-weight: normal;
+}
+.wp-theme-2 .w-box.dark {
+  background: #333;
+}
+.wp-theme-2 .w-box.dark h2 {
+  color: #fff;
+}
+.wp-theme-2 .w-box.white h2 {
+  border-bottom: 0;
+  text-align: center;
+}
+.wp-theme-2 .w-box.white .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.wp-theme-2 .lw .w-box.white {
+  background: #FFF;
+}
+.wp-theme-2 .lw .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-2 .ld .w-box.white {
+  background: #202020;
+  border: 1px solid #444;
+}
+.wp-theme-2 .ld .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-2 .w-box.w-box-inverse .thmb-img i {
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  font-size: 34px;
+  line-height: 100px;
+  text-align: center;
+}
+.wp-theme-2 .lw .w-box.w-box-inverse .thmb-img i {
+  background: #fcfcfc;
+  color: #563d7c;
+}
+.wp-theme-2 .ld .w-box.w-box-inverse .thmb-img i {
+  background: #363636;
+  color: #fff;
+}
+.wp-theme-2 .w-box.w-box-inverse .thmb-img:hover i {
+  background: #563d7c;
+  color: #FFF;
+}
+.wp-theme-2 .c-box {
+  border: 1px solid #563d7c;
+}
+.wp-theme-2 .c-box .c-box-header {
+  padding: 10px 15px;
+  background: #563d7c;
+  color: #fff;
+  font-size: 16px;
+  text-transform: capitalize;
+}
+.wp-theme-2 .c-box .table {
+  margin: 0;
+}
+.wp-theme-2 .ld .w-section h4,
+.wp-theme-2 .ld .w-section h3,
+.wp-theme-2 .ld .w-section h2 {
+  color: #fff;
+}
+.wp-theme-2 .w-section .aside-feature {
+  margin: 10px;
+  cursor: default;
+}
+.wp-theme-2 .w-section .aside-feature .icon-feature {
+  font-size: 68px;
+  margin-top: 10px;
+  text-align: center;
+  display: block;
+}
+.wp-theme-2 .w-section .aside-feature:hover .icon-feature,
+.wp-theme-2 .w-section .aside-feature:hover h4 {
+  color: #563d7c;
+}
+.wp-theme-2 .w-section .aside-feature .img-feature {
+  margin-top: 4px;
+  display: block;
+}
+.wp-theme-2 .w-section .aside-feature .img-feature img {
+  width: 78px;
+}
+.wp-theme-2 .layer-slider-wrapper {
+  max-height: 500px;
+  overflow: hidden;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-2 .layer-slider-wrapper .title {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-2 .layer-slider-wrapper .title.title-base {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #FFF;
+  background: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-2 .layer-slider-wrapper .title.title-dark {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-2 .layer-slider-wrapper .subtitle {
+  font-size: 22px;
+  line-height: 30px;
+  color: #563d7c;
+  text-transform: capitalize;
+}
+.wp-theme-2 .layer-slider-wrapper .list-item {
+  font-size: 18px;
+  line-height: 30px;
+  padding-left: 30px;
+  color: #563d7c;
+  text-transform: capitalize;
+}
+.wp-theme-2 .layer-slider-wrapper .text-standard {
+  font-size: 16px;
+  line-height: 22px;
+}
+.wp-theme-2 .box-element {
+  padding: 20px;
+}
+.wp-theme-2 .box-element:nth-child(n+1) {
+  margin-top: 20px;
+}
+.wp-theme-2 .box-element h1 {
+  margin: 10px 0 !important;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 400;
+}
+.wp-theme-2 .box-element.box-element-bordered {
+  background: transparent !important;
+  border: 1px solid #563d7c;
+}
+.wp-theme-2 .box-element.box-element-outer {
+  padding-left: 0;
+  padding-right: 0;
+}
+.wp-theme-2 .pricing-plans .plan-header .popular-tag {
+  background: #333;
+  border-bottom: 1px solid #FFF;
+  color: #fff;
+}
+.wp-theme-2 .carousel-2 {
+  position: relative;
+}
+.wp-theme-2 .carousel-2 .item {
+  padding: 36px 0 !important;
+}
+.wp-theme-2 .carousel-2 .carousel-indicators {
+  bottom: 0;
+}
+.wp-theme-2 .carousel-2 .carousel-indicators li {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+}
+.wp-theme-2 .carousel-2 .carousel-indicators .active {
+  background-color: #563d7c;
+}
+.wp-theme-2 .carousel-2 .img-thumbnail {
+  margin-top: 26px;
+}
+.wp-theme-2 .carousel-2 h2 {
+  font-size: 22px;
+}
+.wp-theme-2 .carousel-2 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: 10px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #563d7c;
+  opacity: 1;
+}
+.wp-theme-2 .carousel-2 .carousel-nav a:hover {
+  background: #563d7c !important;
+  color: #fff;
+}
+.wp-theme-2 .carousel-2 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-2 .carousel-2 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-2 .carousel-2 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  font-size: 22px;
+  margin-top: -11px;
+}
+.wp-theme-2 .carousel-2 .carousel-control.left i {
+  left: 18px;
+}
+.wp-theme-2 .carousel-2 .carousel-control.right i {
+  right: 18px;
+}
+.wp-theme-2 .carousel-3 {
+  position: relative;
+}
+.wp-theme-2 .carousel-3 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: -50px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #563d7c;
+  opacity: 1;
+}
+.wp-theme-2 .carousel-3 .carousel-nav a:hover {
+  background: #563d7c !important;
+  color: #fff;
+}
+.wp-theme-2 .carousel-3 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-2 .carousel-3 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-2 .carousel-3 .carousel-nav a:hover {
+  background: #FFF;
+}
+.wp-theme-2 .carousel-testimonials {
+  position: relative;
+  border: 1px solid #e0eded;
+}
+.wp-theme-2 .like-button .button {
+  display: block;
+  text-align: right;
+  padding-top: 10px;
+  color: #ddd;
+}
+.wp-theme-2 .like-button .button i {
+  font-size: 20px;
+  color: #ddd;
+}
+.wp-theme-2 .like-button .button.liked i {
+  color: #563d7c;
+}
+.wp-theme-2 .like-button .count {
+  display: block;
+  text-align: right;
+  position: relative;
+  top: -7px;
+}
+.wp-theme-2 .like-button.inline .button {
+  display: inline-block;
+  padding: 0;
+}
+.wp-theme-2 .like-button.inline .count {
+  display: inline-block;
+  top: -2px;
+}
+.wp-theme-2 .like-button.inline .count small {
+  font-size: 13px;
+}
+.wp-theme-2 .side-like-box {
+  text-align: center;
+  padding: 5px 5px 0 5px;
+  margin-top: 10px;
+}
+.wp-theme-2 .side-like-box .button {
+  text-align: center;
+  padding: 0;
+}
+.wp-theme-2 .side-like-box .count {
+  text-align: center;
+}
+.wp-theme-2 .side-like-box i {
+  font-size: 24px;
+}
+.wp-theme-2 ul.list-listings {
+  margin: 0 0 20px 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-2 ul.list-listings li {
+  margin-bottom: 30px;
+  border: 1px solid #f3f3f3;
+  overflow: hidden;
+}
+.wp-theme-2 ul.list-listings li.featured {
+  border-color: #563d7c;
+}
+.wp-theme-2 ul.list-listings li:before,
+.wp-theme-2 ul.list-listings li:after {
+  content: "";
+  display: table;
+}
+.wp-theme-2 ul.list-listings li:after {
+  clear: both;
+}
+.wp-theme-2 ul.list-listings .listing-header {
+  clear: both;
+  padding: 8px 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.wp-theme-2 ul.list-listings .listing-image {
+  width: 25%;
+  height: 150px;
+  float: left;
+  overflow: hidden;
+}
+.wp-theme-2 ul.list-listings .listing-body {
+  width: 50%;
+  height: 150px;
+  padding: 15px;
+  float: left;
+  background: #fcfcfc;
+  border-right: 1px solid #fcfcfc;
+}
+.wp-theme-2 ul.list-listings .listing-body h3 {
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 25px;
+}
+.wp-theme-2 ul.list-listings .listing-body h4 {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 22px;
+}
+.wp-theme-2 ul.list-listings .listing-actions {
+  width: 25%;
+  height: 110px;
+  padding-top: 40px;
+  float: left;
+  text-align: center;
+}
+.wp-theme-2 ul.list-listings .listing-actions .btn {
+  margin-top: 6px;
+}
+.wp-theme-2 ul.list-check {
+  list-style: none;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+}
+.wp-theme-2 ul.list-check li {
+  padding: 4px 0;
+  margin: 0;
+  display: block;
+  width: 100%;
+}
+.wp-theme-2 ul.list-check li i {
+  color: #563d7c;
+  font-style: normal;
+  margin-right: 4px;
+}
+.wp-theme-2 ul.list-check li span {
+  font-size: 14px;
+}
+.wp-theme-2 ul.categories {
+  list-style: none;
+  margin: 0;
+  padding: 0 !important;
+  border: 1px solid #e0eded;
+  overflow: hidden;
+}
+.wp-theme-2 ul.categories li {
+  border-bottom: 1px solid #e0eded;
+  position: reltive;
+}
+.wp-theme-2 ul.categories li:last-child {
+  border: 0;
+}
+.wp-theme-2 ul.categories li a {
+  display: block;
+  padding: 10px 15px;
+}
+.wp-theme-2 ul.categories li a:after {
+  font-family: 'FontAwesome';
+  content: "\f105";
+  position: relative;
+  top: 0;
+  float: right;
+}
+.wp-theme-2 ul.categories li a:hover {
+  background: #563d7c;
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-2 ul.categories li a i {
+  display: inline-block;
+  vertical-align: middle;
+  padding-right: 5px;
+  font-style: normal;
+  color: #999;
+  font-size: 11px;
+}
+.wp-theme-2 ul.categories li a:hover i {
+  color: #FFF;
+}
+.wp-theme-2 .timeline .year {
+  width: 100%;
+  background: #333;
+  padding: 8px 10px;
+  margin: 20px auto 40px !important;
+  font-size: 20px;
+}
+.wp-theme-2 .timeline .year {
+  border-radius: 3px;
+}
+.wp-theme-2 .timeline .event {
+  padding: 0;
+  border: 1px solid #e0eded;
+  border-radius: 0;
+}
+.wp-theme-2 .timeline .event:nth-child(2n):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -6.8% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #563d7c;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-2 .timeline .event:nth-child(2n-1):after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #FFF;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+}
+.wp-theme-2 .timeline .event:nth-child(2n-1):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -6.5% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #563d7c;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-2 .timeline .event-date {
+  margin: 0;
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+  text-align: left;
+  padding: 10px 10px;
+  font-weight: 500;
+  font-size: 14px;
+}
+.wp-theme-2 .timeline .event:nth-child(2n) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-2 .timeline .event:nth-child(2n) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  right: -13px;
+  width: 0;
+  height: 0;
+  border-left: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-2 .timeline .event:nth-child(2n-1) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-2 .timeline .event:nth-child(2n-1) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  left: -13px;
+  width: 0;
+  height: 0;
+  border-right: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-2 .timeline .event-date small {
+  display: block;
+  font-size: 12px;
+  color: #a1a1a1;
+  font-weight: normal;
+}
+.wp-theme-2 .timeline .event-date i {
+  margin-right: 7px;
+}
+.wp-theme-2 .timeline .event-body {
+  background: #f8f8f8;
+}
+.wp-theme-2 .timeline .event-footer {
+  margin: 0;
+  text-align: left;
+  padding: 8px 10px;
+  background: none;
+  border-top: 1px solid #e0eded;
+}
+.wp-theme-2 .timeline .event-footer:after,
+.wp-theme-2 .timeline .event-footer:before {
+  display: table;
+  content: " ";
+}
+.wp-theme-2 .timeline .event-footer:after {
+  clear: both;
+}
+.wp-theme-2 .timeline .event img {
+  margin: 0;
+}
+.wp-theme-2 .timeline p {
+  padding: 20px 10px;
+  text-align: left;
+}
+.wp-theme-2 .timeline iframe {
+  margin: 10px 0 0 0;
+}
+.wp-theme-2 #toTop {
+  display: none;
+  text-decoration: none;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+  border: none;
+  text-indent: 100%;
+  background: #555;
+  border-radius: 3px;
+}
+.wp-theme-2 #toTopHover {
+  background: #563d7c;
+  width: 40px;
+  height: 40px;
+  display: block;
+  overflow: hidden;
+  float: left;
+  opacity: 0;
+  -moz-opacity: 0;
+  filter: alpha(opacity=0);
+}
+.wp-theme-2 #toTop:active,
+.wp-theme-2 #toTop:focus {
+  outline: none;
+}
+.wp-theme-2 #toTop:before {
+  font-family: 'FontAwesome';
+  content: "\f106";
+  color: #ffffff;
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  line-height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  text-indent: 0;
+}
+.wp-theme-2 .widget.tags-wr {
+  padding-bottom: 15px;
+}
+.wp-theme-2 .tags-list:before,
+.wp-theme-2 .tags-list:after {
+  display: table;
+  content: "";
+}
+.wp-theme-2 .tags-list:after {
+  clear: both;
+}
+.wp-theme-2 .tags-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.wp-theme-2 .tags-list li {
+  border: 1px solid #563d7c;
+  background: #FFF;
+  padding: 5px;
+  float: left;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  color: #563d7c;
+  font-size: 12px;
+}
+.wp-theme-2 .tags-list li a {
+  color: #563d7c;
+  margin-left: 4px;
+}
+.wp-theme-2 .tags-list li:hover {
+  background: #563d7c;
+  color: #FFF;
+}
+.wp-theme-2 .tags-list li:hover a {
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-3 {
+  /* LAYER SLIDER CUSTOMS */
+  /* BOX ELEMENTS */
+  /* TAG CLOUD */
+}
+.wp-theme-3 .btn {
+  font-weight: normal;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+.wp-theme-3 .btn i {
+  margin-right: 4px;
+}
+.wp-theme-3 .btn-lg {
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 3px;
+}
+.wp-theme-3 .btn-lg i {
+  font-size: 24px;
+  position: relative;
+  top: 3px;
+}
+.wp-theme-3 .btn-xs {
+  padding: 4px 10px;
+}
+.wp-theme-3 .btn-one {
+  background-color: none;
+  border: 2px solid #FFF;
+  color: #FFF;
+}
+.wp-theme-3 .btn-one:hover,
+.wp-theme-3 .btn-one:focus,
+.wp-theme-3 .btn-one:active,
+.wp-theme-3 .btn-one.active,
+.wp-theme-3 .open .dropdown-toggle.btn-one {
+  color: #59b2e5;
+  background-color: #FFF;
+  border-color: #FFF;
+}
+.wp-theme-3 .btn-one:active,
+.wp-theme-3 .btn-one.active,
+.wp-theme-3 .open .dropdown-toggle.btn-one {
+  background-image: none;
+}
+.wp-theme-3 .btn-two {
+  color: #ffffff;
+  background-color: #59b2e5;
+  border: 1px solid;
+  border-color: #4fa8db;
+}
+.wp-theme-3 .btn-two:hover,
+.wp-theme-3 .btn-two:focus,
+.wp-theme-3 .btn-two:active,
+.wp-theme-3 .btn-two.active,
+.wp-theme-3 .open .dropdown-toggle.btn-two {
+  color: #ffffff;
+  background-color: #459ed1;
+  border-color: #459ed1;
+}
+.wp-theme-3 .btn-two:active,
+.wp-theme-3 .btn-two.active,
+.wp-theme-3 .open .dropdown-toggle.btn-two {
+  background-image: none;
+}
+.wp-theme-3 .btn-three {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid;
+  border-color: #292929;
+}
+.wp-theme-3 .btn-three:hover,
+.wp-theme-3 .btn-three:focus,
+.wp-theme-3 .btn-three:active,
+.wp-theme-3 .btn-three.active,
+.wp-theme-3 .open .dropdown-toggle.btn-three {
+  color: #ffffff;
+  background-color: #1f1f1f;
+  border-color: #1f1f1f;
+}
+.wp-theme-3 .btn-three:active,
+.wp-theme-3 .btn-three.active,
+.wp-theme-3 .open .dropdown-toggle.btn-three {
+  background-image: none;
+}
+.wp-theme-3 .btn-four {
+  background-color: none;
+  border: 2px solid #59b2e5;
+  color: #59b2e5;
+}
+.wp-theme-3 .btn-four:hover,
+.wp-theme-3 .btn-four:focus,
+.wp-theme-3 .btn-four:active,
+.wp-theme-3 .btn-four.active,
+.wp-theme-3 .open .dropdown-toggle.btn-four {
+  color: #FFF;
+  background-color: #59b2e5;
+}
+.wp-theme-3 .btn-four:active,
+.wp-theme-3 .btn-four.active,
+.wp-theme-3 .open .dropdown-toggle.btn-four {
+  background-image: none;
+}
+.wp-theme-3 h1,
+.wp-theme-3 h2,
+.wp-theme-3 h3,
+.wp-theme-3 h4,
+.wp-theme-3 h5,
+.wp-theme-3 h6 {
+  font-family: "Roboto", sans-serif !important;
+}
+.wp-theme-3 p {
+  line-height: 22px;
+}
+.wp-theme-3 a {
+  color: #616161;
+  cursor: pointer;
+}
+.wp-theme-3 a:hover {
+  color: #59b2e5;
+  text-decoration: none;
+  -o-transition: .3s;
+  -ms-transition: .3s;
+  -moz-transition: .3s;
+  -webkit-transition: .3s;
+  transition: .35s;
+}
+.wp-theme-3 .bg-2 {
+  background: #59b2e5;
+  color: #FFF;
+}
+.wp-theme-3 .lw .bg-5 {
+  background: #fcfcfc;
+  border-top: 1px solid #e0eded;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-3 .ld .bg-5 {
+  background: #363636;
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-3 .lw .bg-3 {
+  background: #fff;
+  color: #616161;
+}
+.wp-theme-3 .ld .bg-3 {
+  background: #202020;
+  color: #888;
+}
+.wp-theme-3 .bg-4 {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-3 .dark {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-3 .red {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-3 .orange {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-3 .green {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-3 .blue {
+  background: #3498db;
+  color: #FFF;
+}
+.wp-theme-3 .light {
+  background: #fff;
+  color: #616161 !important;
+}
+.wp-theme-3 .blockquote-1:hover {
+  border-color: #59b2e5;
+}
+.wp-theme-3 .blockquote-1 p {
+  font-size: 13px;
+}
+.wp-theme-3 .section-title {
+  display: inline-block;
+  border-bottom: 1px solid #333;
+  margin: 0 0 15px 0;
+  padding: 0 0 5px 0;
+  font-size: 20px;
+  font-weight: 500;
+  text-transform: capitalize;
+  position: relative;
+  overflow: hidden;
+}
+.wp-theme-3 .lw .section-title {
+  color: #333;
+}
+.wp-theme-3 .ld .section-title {
+  color: #fff;
+}
+.wp-theme-3 .section-title.white {
+  color: #fff;
+  border-bottom: 1px solid #fff;
+}
+.wp-theme-3 .navbar-wp {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  z-index: 1000;
+}
+.wp-theme-3 .lw .navbar-wp {
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-3 .ld .navbar-wp {
+  background: #181818;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-3 .ld .sticky-wrapper .navbar-wp {
+  background: rgba(24, 24, 24, 0.85);
+  border-bottom: 1px solid #444;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > li > a {
+  padding: 28px 16px;
+  margin-right: 0;
+  font-size: 15px;
+  font-weight: normal;
+}
+.wp-theme-3 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-3 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-3 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-3 .lw .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #333;
+}
+.wp-theme-3 .lw .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-3 .lw .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #59b2e5;
+}
+.wp-theme-3 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-3 .ld .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #fff;
+}
+.wp-theme-3 .ld .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-3 .ld .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #59b2e5;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > .active > a,
+.wp-theme-3 .navbar-wp .navbar-nav > .active > a:hover,
+.wp-theme-3 .navbar-wp .navbar-nav > .active > a:focus {
+  color: #fff !important;
+  background-color: #59b2e5;
+  border-radius: 0;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > .disabled > a,
+.wp-theme-3 .navbar-wp .navbar-nav > .disabled > a:hover,
+.wp-theme-3 .navbar-wp .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a,
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a:hover,
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a:focus {
+  color: #FFF !important;
+  background-color: #59b2e5;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a .caret,
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a:hover .caret,
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle,
+.wp-theme-3 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-3 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:focus {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+  color: #59b2e5;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle,
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:hover,
+.wp-theme-3 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:focus {
+  color: #59b2e5 !important;
+  background-color: none;
+}
+.wp-theme-3 .navbar-wp .navbar-toggle {
+  border-color: #333;
+  margin-top: 20px;
+}
+.wp-theme-3 .navbar-wp .navbar-toggle .icon-bar {
+  background-color: #4c4c4c;
+}
+.wp-theme-3 .navbar-wp .navbar-toggle .icon-custom {
+  font-size: 18px;
+}
+.wp-theme-3 .navbar-wp .navbar-toggle:hover,
+.wp-theme-3 .navbar-wp .navbar-toggle:focus {
+  background-color: #59b2e5;
+  border-color: #59b2e5;
+}
+.wp-theme-3 .navbar-wp .navbar-toggle:hover .icon-bar,
+.wp-theme-3 .navbar-wp .navbar-toggle:focus .icon-bar {
+  background-color: #FFF;
+}
+.wp-theme-3 .navbar-wp .navbar-toggle:hover .icon-custom,
+.wp-theme-3 .navbar-wp .navbar-toggle:focus .icon-custom {
+  color: #FFF;
+}
+.wp-theme-3 .navbar-wp .navbar-toggle-aside-menu {
+  padding: 8px 10px 2px 10px;
+}
+.wp-theme-3 .navbar-wp .navbar-collapse,
+.wp-theme-3 .navbar-wp .navbar-form {
+  border-color: #e7e7e7;
+}
+.wp-theme-3 .navbar-wp .navbar-nav > .dropdown > a:hover .caret,
+.wp-theme-3 .navbar-wp .navbar-nav > .dropdown > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu {
+  min-width: 220px;
+  background: #FFF;
+  border: 0;
+  border-top: 1px solid #59b2e5;
+  border-bottom: 3px solid #59b2e5;
+  border-radius: 0;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu > li {
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu > li:last-child {
+  border: 0;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu > li > a {
+  color: #333;
+  padding: 8px 15px;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu > li > a:hover {
+  background: #59b2e5;
+  color: #FFF;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu label.checkbox {
+  color: #333;
+}
+.wp-theme-3 .navbar-wp .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu-user {
+  border: 1px solid #e0eded;
+  border-top-color: transparent;
+}
+.wp-theme-3 .navbar-wp .dropdown-menu-user {
+  background: #fff;
+}
+.wp-theme-3 .navbar-wp .navbar-right .dropdown-menu-user {
+  background: #fff;
+  border-color: transparent;
+}
+.wp-theme-3 .navbar-wp .navbar-right .social-link {
+  width: 40px;
+  height: 40px;
+  line-height: 20px;
+  text-align: center;
+  padding: 10px;
+  margin: 18px 0;
+  border-radius: 100%;
+}
+.wp-theme-3 .navbar-wp .navbar-right .social-link.facebook:hover {
+  background: #43609c;
+  color: #fff;
+}
+.wp-theme-3 .navbar-wp .navbar-right .social-link.pinterest:hover {
+  background: #cb2027;
+  color: #fff;
+}
+.wp-theme-3 .navbar-wp .navbar-right .social-link.twitter:hover {
+  background: #62addb;
+  color: #fff;
+}
+.wp-theme-3 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-3 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-3 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-3 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > .open > a,
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover,
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus {
+  color: #FFF;
+  background-color: #2c2c2c;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > .open > a .caret,
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover .caret,
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:focus {
+  background: none;
+  color: #59b2e5;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  bottom: 100%;
+  right: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-right: -35px;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  bottom: 100%;
+  left: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-left: -35px;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu {
+  min-width: 220px;
+  background: #2c2c2c;
+  border: 0;
+  border-top: 0;
+  border-bottom: 0;
+  border-radius: 0;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu > li {
+  border-bottom: 1px solid #262626;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu > li > a {
+  color: #fff;
+  padding: 8px 15px;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu > li > a:hover {
+  background: #59b2e5;
+  color: #FFF;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox {
+  color: #fff;
+}
+.wp-theme-3 .navbar-wp.navbar-contrasted .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-3 .dropdown-submenu {
+  position: relative;
+}
+.wp-theme-3 .dropdown-submenu > .dropdown-menu {
+  top: -5px;
+  left: 100%;
+  margin-top: 0;
+  margin-left: -1px;
+}
+.wp-theme-3 .dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+.wp-theme-3 .dropdown-submenu > a:after {
+  display: block;
+  content: " ";
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 3px 0 3px 3px;
+  border-left-color: #ccc;
+  margin-top: 5px;
+  margin-right: -6px;
+}
+.wp-theme-3 .dropdown-submenu:hover > a:after {
+  border-left-color: #fff;
+}
+.wp-theme-3 .dropdown-submenu.pull-left {
+  float: none;
+}
+.wp-theme-3 .dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+}
+.wp-theme-3 .nav > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-3 .nav > ul > li {
+  border-bottom: 1px solid #333;
+}
+.wp-theme-3 .nav > ul > li > a {
+  display: block;
+  padding: 10px 15px;
+  font-size: 14px;
+  color: #fff;
+}
+.wp-theme-3 .nav > ul > li > a:hover {
+  text-decoration: none;
+  color: #59b2e5;
+  background: #292929;
+}
+.wp-theme-3 .nav > ul > li > a > i {
+  margin-right: 5px;
+}
+.wp-theme-3 .lw .pg-opt {
+  border-bottom: 1px solid #e0eded;
+  background: #fcfcfc;
+}
+.wp-theme-3 .ld .pg-opt {
+  border-bottom: 1px solid #444;
+  background: #111;
+}
+.wp-theme-3 .pg-opt.fixed {
+  width: 100%;
+  position: fixed;
+  top: 0px;
+  background: rgba(250, 250, 250, 0.9);
+  border-bottom: 1px solid #e0eded;
+  z-index: 900;
+}
+.wp-theme-3 .pg-opt h2 {
+  margin: 0;
+  padding: 14px 0;
+  font-size: 22px;
+  line-height: 100%;
+}
+.wp-theme-3 .pg-opt.fixed h2 {
+  margin-bottom: 15px;
+}
+.wp-theme-3 .pg-opt hr {
+  margin: 0;
+  border-top-color: #dde1e6;
+  -webkit-box-shadow: 0 1px 0 #fbfbfc;
+  -moz-box-shadow: 0 1px 0 #fbfbfc;
+  box-shadow: 0 1px 0 #fbfbfc;
+}
+.wp-theme-3 .pg-opt.fixed hr {
+  display: none;
+}
+.wp-theme-3 .pg-opt .breadcrumb {
+  float: right;
+  margin: 0;
+  padding: 16px 0;
+  background: none;
+  border-radius: 0;
+}
+.wp-theme-3 .pg-opt .breadcrumb a {
+  color: #59b2e5;
+}
+@media only screen and (max-width: 767px) {
+  .wp-theme-3 .pg-opt .pg-nav {
+    float: left;
+    margin-bottom: 10px;
+  }
+  .wp-theme-3 .pg-opt h2 {
+    padding: 20px 0 0 0;
+  }
+}
+.wp-theme-3 .page-header {
+  margin: 0;
+  border: 0;
+}
+.wp-theme-3 .page-header p {
+  font-size: 16px;
+}
+.wp-theme-3 .w-box {
+  margin: 0 0 15px 0;
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+  border: 1px solid #e0eded;
+}
+.wp-theme-3 .w-box:before,
+.wp-theme-3 .w-box:after {
+  display: table;
+  content: "";
+}
+.wp-theme-3 .w-box:after {
+  clear: both;
+}
+.wp-theme-3 .w-box h1 {
+  margin: 0;
+  padding: 10px 15px;
+  font-weight: 500;
+  font-size: 20px;
+}
+.wp-theme-3 .lw .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #333;
+}
+.wp-theme-3 .ld .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #fff;
+}
+.wp-theme-3 .w-box.inner h2 {
+  padding: 10px 0;
+}
+.wp-theme-3 .w-box small {
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+.wp-theme-3 .w-box p {
+  margin: 6px 0;
+  padding: 0 15px;
+  padding-bottom: 8px;
+}
+.wp-theme-3 .w-box time {
+  display: block;
+  padding: 8px 15px 0 15px;
+}
+.wp-theme-3 .w-box .w-footer {
+  padding: 10px 15px;
+  border-top: 1px solid #f1f1f1;
+}
+.wp-theme-3 .w-box .w-footer:before,
+.wp-theme-3 .w-box .w-footer:after {
+  display: table;
+  content: "";
+}
+.wp-theme-3 .w-box .w-footer:after {
+  clear: both;
+}
+.wp-theme-3 .w-box .w-footer small {
+  font-size: 12px;
+}
+.wp-theme-3 .w-box .w-box-parent {
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+}
+.wp-theme-3 .w-box .date-over {
+  padding: 10px;
+  background: #ffffff;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  text-align: center;
+  font-weight: normal;
+}
+.wp-theme-3 .w-box .date-over.small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.wp-theme-3 .w-box .date-over strong {
+  font-size: 12px;
+  display: block;
+  font-weight: normal;
+}
+.wp-theme-3 .w-box.dark {
+  background: #333;
+}
+.wp-theme-3 .w-box.dark h2 {
+  color: #fff;
+}
+.wp-theme-3 .w-box.white h2 {
+  border-bottom: 0;
+  text-align: center;
+}
+.wp-theme-3 .w-box.white .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.wp-theme-3 .lw .w-box.white {
+  background: #FFF;
+}
+.wp-theme-3 .lw .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-3 .ld .w-box.white {
+  background: #202020;
+  border: 1px solid #444;
+}
+.wp-theme-3 .ld .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-3 .w-box.w-box-inverse .thmb-img i {
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  font-size: 34px;
+  line-height: 100px;
+  text-align: center;
+}
+.wp-theme-3 .lw .w-box.w-box-inverse .thmb-img i {
+  background: #fcfcfc;
+  color: #59b2e5;
+}
+.wp-theme-3 .ld .w-box.w-box-inverse .thmb-img i {
+  background: #363636;
+  color: #fff;
+}
+.wp-theme-3 .w-box.w-box-inverse .thmb-img:hover i {
+  background: #59b2e5;
+  color: #FFF;
+}
+.wp-theme-3 .c-box {
+  border: 1px solid #59b2e5;
+}
+.wp-theme-3 .c-box .c-box-header {
+  padding: 10px 15px;
+  background: #59b2e5;
+  color: #fff;
+  font-size: 16px;
+  text-transform: capitalize;
+}
+.wp-theme-3 .c-box .table {
+  margin: 0;
+}
+.wp-theme-3 .ld .w-section h4,
+.wp-theme-3 .ld .w-section h3,
+.wp-theme-3 .ld .w-section h2 {
+  color: #fff;
+}
+.wp-theme-3 .w-section .aside-feature {
+  margin: 10px;
+  cursor: default;
+}
+.wp-theme-3 .w-section .aside-feature .icon-feature {
+  font-size: 68px;
+  margin-top: 10px;
+  text-align: center;
+  display: block;
+}
+.wp-theme-3 .w-section .aside-feature:hover .icon-feature,
+.wp-theme-3 .w-section .aside-feature:hover h4 {
+  color: #59b2e5;
+}
+.wp-theme-3 .w-section .aside-feature .img-feature {
+  margin-top: 4px;
+  display: block;
+}
+.wp-theme-3 .w-section .aside-feature .img-feature img {
+  width: 78px;
+}
+.wp-theme-3 .layer-slider-wrapper {
+  max-height: 500px;
+  overflow: hidden;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-3 .layer-slider-wrapper .title {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-3 .layer-slider-wrapper .title.title-base {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #FFF;
+  background: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-3 .layer-slider-wrapper .title.title-dark {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-3 .layer-slider-wrapper .subtitle {
+  font-size: 22px;
+  line-height: 30px;
+  color: #59b2e5;
+  text-transform: capitalize;
+}
+.wp-theme-3 .layer-slider-wrapper .list-item {
+  font-size: 18px;
+  line-height: 30px;
+  padding-left: 30px;
+  color: #59b2e5;
+  text-transform: capitalize;
+}
+.wp-theme-3 .layer-slider-wrapper .text-standard {
+  font-size: 16px;
+  line-height: 22px;
+}
+.wp-theme-3 .box-element {
+  padding: 20px;
+}
+.wp-theme-3 .box-element:nth-child(n+1) {
+  margin-top: 20px;
+}
+.wp-theme-3 .box-element h1 {
+  margin: 10px 0 !important;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 400;
+}
+.wp-theme-3 .box-element.box-element-bordered {
+  background: transparent !important;
+  border: 1px solid #59b2e5;
+}
+.wp-theme-3 .box-element.box-element-outer {
+  padding-left: 0;
+  padding-right: 0;
+}
+.wp-theme-3 .pricing-plans .plan-header .popular-tag {
+  background: #333;
+  border-bottom: 1px solid #FFF;
+  color: #fff;
+}
+.wp-theme-3 .carousel-2 {
+  position: relative;
+}
+.wp-theme-3 .carousel-2 .item {
+  padding: 36px 0 !important;
+}
+.wp-theme-3 .carousel-2 .carousel-indicators {
+  bottom: 0;
+}
+.wp-theme-3 .carousel-2 .carousel-indicators li {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+}
+.wp-theme-3 .carousel-2 .carousel-indicators .active {
+  background-color: #59b2e5;
+}
+.wp-theme-3 .carousel-2 .img-thumbnail {
+  margin-top: 26px;
+}
+.wp-theme-3 .carousel-2 h2 {
+  font-size: 22px;
+}
+.wp-theme-3 .carousel-2 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: 10px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #59b2e5;
+  opacity: 1;
+}
+.wp-theme-3 .carousel-2 .carousel-nav a:hover {
+  background: #59b2e5 !important;
+  color: #fff;
+}
+.wp-theme-3 .carousel-2 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-3 .carousel-2 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-3 .carousel-2 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  font-size: 22px;
+  margin-top: -11px;
+}
+.wp-theme-3 .carousel-2 .carousel-control.left i {
+  left: 18px;
+}
+.wp-theme-3 .carousel-2 .carousel-control.right i {
+  right: 18px;
+}
+.wp-theme-3 .carousel-3 {
+  position: relative;
+}
+.wp-theme-3 .carousel-3 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: -50px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #59b2e5;
+  opacity: 1;
+}
+.wp-theme-3 .carousel-3 .carousel-nav a:hover {
+  background: #59b2e5 !important;
+  color: #fff;
+}
+.wp-theme-3 .carousel-3 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-3 .carousel-3 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-3 .carousel-3 .carousel-nav a:hover {
+  background: #FFF;
+}
+.wp-theme-3 .carousel-testimonials {
+  position: relative;
+  border: 1px solid #e0eded;
+}
+.wp-theme-3 .like-button .button {
+  display: block;
+  text-align: right;
+  padding-top: 10px;
+  color: #ddd;
+}
+.wp-theme-3 .like-button .button i {
+  font-size: 20px;
+  color: #ddd;
+}
+.wp-theme-3 .like-button .button.liked i {
+  color: #59b2e5;
+}
+.wp-theme-3 .like-button .count {
+  display: block;
+  text-align: right;
+  position: relative;
+  top: -7px;
+}
+.wp-theme-3 .like-button.inline .button {
+  display: inline-block;
+  padding: 0;
+}
+.wp-theme-3 .like-button.inline .count {
+  display: inline-block;
+  top: -2px;
+}
+.wp-theme-3 .like-button.inline .count small {
+  font-size: 13px;
+}
+.wp-theme-3 .side-like-box {
+  text-align: center;
+  padding: 5px 5px 0 5px;
+  margin-top: 10px;
+}
+.wp-theme-3 .side-like-box .button {
+  text-align: center;
+  padding: 0;
+}
+.wp-theme-3 .side-like-box .count {
+  text-align: center;
+}
+.wp-theme-3 .side-like-box i {
+  font-size: 24px;
+}
+.wp-theme-3 ul.list-listings {
+  margin: 0 0 20px 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-3 ul.list-listings li {
+  margin-bottom: 30px;
+  border: 1px solid #f3f3f3;
+  overflow: hidden;
+}
+.wp-theme-3 ul.list-listings li.featured {
+  border-color: #59b2e5;
+}
+.wp-theme-3 ul.list-listings li:before,
+.wp-theme-3 ul.list-listings li:after {
+  content: "";
+  display: table;
+}
+.wp-theme-3 ul.list-listings li:after {
+  clear: both;
+}
+.wp-theme-3 ul.list-listings .listing-header {
+  clear: both;
+  padding: 8px 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.wp-theme-3 ul.list-listings .listing-image {
+  width: 25%;
+  height: 150px;
+  float: left;
+  overflow: hidden;
+}
+.wp-theme-3 ul.list-listings .listing-body {
+  width: 50%;
+  height: 150px;
+  padding: 15px;
+  float: left;
+  background: #fcfcfc;
+  border-right: 1px solid #fcfcfc;
+}
+.wp-theme-3 ul.list-listings .listing-body h3 {
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 25px;
+}
+.wp-theme-3 ul.list-listings .listing-body h4 {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 22px;
+}
+.wp-theme-3 ul.list-listings .listing-actions {
+  width: 25%;
+  height: 110px;
+  padding-top: 40px;
+  float: left;
+  text-align: center;
+}
+.wp-theme-3 ul.list-listings .listing-actions .btn {
+  margin-top: 6px;
+}
+.wp-theme-3 ul.list-check {
+  list-style: none;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+}
+.wp-theme-3 ul.list-check li {
+  padding: 4px 0;
+  margin: 0;
+  display: block;
+  width: 100%;
+}
+.wp-theme-3 ul.list-check li i {
+  color: #59b2e5;
+  font-style: normal;
+  margin-right: 4px;
+}
+.wp-theme-3 ul.list-check li span {
+  font-size: 14px;
+}
+.wp-theme-3 ul.categories {
+  list-style: none;
+  margin: 0;
+  padding: 0 !important;
+  border: 1px solid #e0eded;
+  overflow: hidden;
+}
+.wp-theme-3 ul.categories li {
+  border-bottom: 1px solid #e0eded;
+  position: reltive;
+}
+.wp-theme-3 ul.categories li:last-child {
+  border: 0;
+}
+.wp-theme-3 ul.categories li a {
+  display: block;
+  padding: 10px 15px;
+}
+.wp-theme-3 ul.categories li a:after {
+  font-family: 'FontAwesome';
+  content: "\f105";
+  position: relative;
+  top: 0;
+  float: right;
+}
+.wp-theme-3 ul.categories li a:hover {
+  background: #59b2e5;
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-3 ul.categories li a i {
+  display: inline-block;
+  vertical-align: middle;
+  padding-right: 5px;
+  font-style: normal;
+  color: #999;
+  font-size: 11px;
+}
+.wp-theme-3 ul.categories li a:hover i {
+  color: #FFF;
+}
+.wp-theme-3 .timeline .year {
+  width: 100%;
+  background: #333;
+  padding: 8px 10px;
+  margin: 20px auto 40px !important;
+  font-size: 20px;
+}
+.wp-theme-3 .timeline .year {
+  border-radius: 3px;
+}
+.wp-theme-3 .timeline .event {
+  padding: 0;
+  border: 1px solid #e0eded;
+  border-radius: 0;
+}
+.wp-theme-3 .timeline .event:nth-child(2n):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -6.8% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #59b2e5;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-3 .timeline .event:nth-child(2n-1):after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #FFF;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+}
+.wp-theme-3 .timeline .event:nth-child(2n-1):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -6.5% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #59b2e5;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-3 .timeline .event-date {
+  margin: 0;
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+  text-align: left;
+  padding: 10px 10px;
+  font-weight: 500;
+  font-size: 14px;
+}
+.wp-theme-3 .timeline .event:nth-child(2n) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-3 .timeline .event:nth-child(2n) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  right: -13px;
+  width: 0;
+  height: 0;
+  border-left: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-3 .timeline .event:nth-child(2n-1) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-3 .timeline .event:nth-child(2n-1) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  left: -13px;
+  width: 0;
+  height: 0;
+  border-right: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-3 .timeline .event-date small {
+  display: block;
+  font-size: 12px;
+  color: #a1a1a1;
+  font-weight: normal;
+}
+.wp-theme-3 .timeline .event-date i {
+  margin-right: 7px;
+}
+.wp-theme-3 .timeline .event-body {
+  background: #f8f8f8;
+}
+.wp-theme-3 .timeline .event-footer {
+  margin: 0;
+  text-align: left;
+  padding: 8px 10px;
+  background: none;
+  border-top: 1px solid #e0eded;
+}
+.wp-theme-3 .timeline .event-footer:after,
+.wp-theme-3 .timeline .event-footer:before {
+  display: table;
+  content: " ";
+}
+.wp-theme-3 .timeline .event-footer:after {
+  clear: both;
+}
+.wp-theme-3 .timeline .event img {
+  margin: 0;
+}
+.wp-theme-3 .timeline p {
+  padding: 20px 10px;
+  text-align: left;
+}
+.wp-theme-3 .timeline iframe {
+  margin: 10px 0 0 0;
+}
+.wp-theme-3 #toTop {
+  display: none;
+  text-decoration: none;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+  border: none;
+  text-indent: 100%;
+  background: #555;
+  border-radius: 3px;
+}
+.wp-theme-3 #toTopHover {
+  background: #59b2e5;
+  width: 40px;
+  height: 40px;
+  display: block;
+  overflow: hidden;
+  float: left;
+  opacity: 0;
+  -moz-opacity: 0;
+  filter: alpha(opacity=0);
+}
+.wp-theme-3 #toTop:active,
+.wp-theme-3 #toTop:focus {
+  outline: none;
+}
+.wp-theme-3 #toTop:before {
+  font-family: 'FontAwesome';
+  content: "\f106";
+  color: #ffffff;
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  line-height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  text-indent: 0;
+}
+.wp-theme-3 .widget.tags-wr {
+  padding-bottom: 15px;
+}
+.wp-theme-3 .tags-list:before,
+.wp-theme-3 .tags-list:after {
+  display: table;
+  content: "";
+}
+.wp-theme-3 .tags-list:after {
+  clear: both;
+}
+.wp-theme-3 .tags-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.wp-theme-3 .tags-list li {
+  border: 1px solid #59b2e5;
+  background: #FFF;
+  padding: 5px;
+  float: left;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  color: #59b2e5;
+  font-size: 12px;
+}
+.wp-theme-3 .tags-list li a {
+  color: #59b2e5;
+  margin-left: 4px;
+}
+.wp-theme-3 .tags-list li:hover {
+  background: #59b2e5;
+  color: #FFF;
+}
+.wp-theme-3 .tags-list li:hover a {
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-4 {
+  /* LAYER SLIDER CUSTOMS */
+  /* BOX ELEMENTS */
+  /* TAG CLOUD */
+}
+.wp-theme-4 .btn {
+  font-weight: normal;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+.wp-theme-4 .btn i {
+  margin-right: 4px;
+}
+.wp-theme-4 .btn-lg {
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 3px;
+}
+.wp-theme-4 .btn-lg i {
+  font-size: 24px;
+  position: relative;
+  top: 3px;
+}
+.wp-theme-4 .btn-xs {
+  padding: 4px 10px;
+}
+.wp-theme-4 .btn-one {
+  background-color: none;
+  border: 2px solid #FFF;
+  color: #FFF;
+}
+.wp-theme-4 .btn-one:hover,
+.wp-theme-4 .btn-one:focus,
+.wp-theme-4 .btn-one:active,
+.wp-theme-4 .btn-one.active,
+.wp-theme-4 .open .dropdown-toggle.btn-one {
+  color: #8ec449;
+  background-color: #FFF;
+  border-color: #FFF;
+}
+.wp-theme-4 .btn-one:active,
+.wp-theme-4 .btn-one.active,
+.wp-theme-4 .open .dropdown-toggle.btn-one {
+  background-image: none;
+}
+.wp-theme-4 .btn-two {
+  color: #ffffff;
+  background-color: #8ec449;
+  border: 1px solid;
+  border-color: #84ba3f;
+}
+.wp-theme-4 .btn-two:hover,
+.wp-theme-4 .btn-two:focus,
+.wp-theme-4 .btn-two:active,
+.wp-theme-4 .btn-two.active,
+.wp-theme-4 .open .dropdown-toggle.btn-two {
+  color: #ffffff;
+  background-color: #7ab035;
+  border-color: #7ab035;
+}
+.wp-theme-4 .btn-two:active,
+.wp-theme-4 .btn-two.active,
+.wp-theme-4 .open .dropdown-toggle.btn-two {
+  background-image: none;
+}
+.wp-theme-4 .btn-three {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid;
+  border-color: #292929;
+}
+.wp-theme-4 .btn-three:hover,
+.wp-theme-4 .btn-three:focus,
+.wp-theme-4 .btn-three:active,
+.wp-theme-4 .btn-three.active,
+.wp-theme-4 .open .dropdown-toggle.btn-three {
+  color: #ffffff;
+  background-color: #1f1f1f;
+  border-color: #1f1f1f;
+}
+.wp-theme-4 .btn-three:active,
+.wp-theme-4 .btn-three.active,
+.wp-theme-4 .open .dropdown-toggle.btn-three {
+  background-image: none;
+}
+.wp-theme-4 .btn-four {
+  background-color: none;
+  border: 2px solid #8ec449;
+  color: #8ec449;
+}
+.wp-theme-4 .btn-four:hover,
+.wp-theme-4 .btn-four:focus,
+.wp-theme-4 .btn-four:active,
+.wp-theme-4 .btn-four.active,
+.wp-theme-4 .open .dropdown-toggle.btn-four {
+  color: #FFF;
+  background-color: #8ec449;
+}
+.wp-theme-4 .btn-four:active,
+.wp-theme-4 .btn-four.active,
+.wp-theme-4 .open .dropdown-toggle.btn-four {
+  background-image: none;
+}
+.wp-theme-4 h1,
+.wp-theme-4 h2,
+.wp-theme-4 h3,
+.wp-theme-4 h4,
+.wp-theme-4 h5,
+.wp-theme-4 h6 {
+  font-family: "Roboto", sans-serif !important;
+}
+.wp-theme-4 p {
+  line-height: 22px;
+}
+.wp-theme-4 a {
+  color: #616161;
+  cursor: pointer;
+}
+.wp-theme-4 a:hover {
+  color: #8ec449;
+  text-decoration: none;
+  -o-transition: .3s;
+  -ms-transition: .3s;
+  -moz-transition: .3s;
+  -webkit-transition: .3s;
+  transition: .35s;
+}
+.wp-theme-4 .bg-2 {
+  background: #8ec449;
+  color: #FFF;
+}
+.wp-theme-4 .lw .bg-5 {
+  background: #fcfcfc;
+  border-top: 1px solid #e0eded;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-4 .ld .bg-5 {
+  background: #363636;
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-4 .lw .bg-3 {
+  background: #fff;
+  color: #616161;
+}
+.wp-theme-4 .ld .bg-3 {
+  background: #202020;
+  color: #888;
+}
+.wp-theme-4 .bg-4 {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-4 .dark {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-4 .red {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-4 .orange {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-4 .green {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-4 .blue {
+  background: #3498db;
+  color: #FFF;
+}
+.wp-theme-4 .light {
+  background: #fff;
+  color: #616161 !important;
+}
+.wp-theme-4 .blockquote-1:hover {
+  border-color: #8ec449;
+}
+.wp-theme-4 .blockquote-1 p {
+  font-size: 13px;
+}
+.wp-theme-4 .section-title {
+  display: inline-block;
+  border-bottom: 1px solid #333;
+  margin: 0 0 15px 0;
+  padding: 0 0 5px 0;
+  font-size: 20px;
+  font-weight: 500;
+  text-transform: capitalize;
+  position: relative;
+  overflow: hidden;
+}
+.wp-theme-4 .lw .section-title {
+  color: #333;
+}
+.wp-theme-4 .ld .section-title {
+  color: #fff;
+}
+.wp-theme-4 .section-title.white {
+  color: #fff;
+  border-bottom: 1px solid #fff;
+}
+.wp-theme-4 .navbar-wp {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  z-index: 1000;
+}
+.wp-theme-4 .lw .navbar-wp {
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-4 .ld .navbar-wp {
+  background: #181818;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-4 .ld .sticky-wrapper .navbar-wp {
+  background: rgba(24, 24, 24, 0.85);
+  border-bottom: 1px solid #444;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > li > a {
+  padding: 28px 16px;
+  margin-right: 0;
+  font-size: 15px;
+  font-weight: normal;
+}
+.wp-theme-4 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-4 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-4 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-4 .lw .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #333;
+}
+.wp-theme-4 .lw .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-4 .lw .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #8ec449;
+}
+.wp-theme-4 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-4 .ld .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #fff;
+}
+.wp-theme-4 .ld .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-4 .ld .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #8ec449;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > .active > a,
+.wp-theme-4 .navbar-wp .navbar-nav > .active > a:hover,
+.wp-theme-4 .navbar-wp .navbar-nav > .active > a:focus {
+  color: #fff !important;
+  background-color: #8ec449;
+  border-radius: 0;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > .disabled > a,
+.wp-theme-4 .navbar-wp .navbar-nav > .disabled > a:hover,
+.wp-theme-4 .navbar-wp .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a,
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a:hover,
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a:focus {
+  color: #FFF !important;
+  background-color: #8ec449;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a .caret,
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a:hover .caret,
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle,
+.wp-theme-4 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-4 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:focus {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+  color: #8ec449;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle,
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:hover,
+.wp-theme-4 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:focus {
+  color: #8ec449 !important;
+  background-color: none;
+}
+.wp-theme-4 .navbar-wp .navbar-toggle {
+  border-color: #333;
+  margin-top: 20px;
+}
+.wp-theme-4 .navbar-wp .navbar-toggle .icon-bar {
+  background-color: #4c4c4c;
+}
+.wp-theme-4 .navbar-wp .navbar-toggle .icon-custom {
+  font-size: 18px;
+}
+.wp-theme-4 .navbar-wp .navbar-toggle:hover,
+.wp-theme-4 .navbar-wp .navbar-toggle:focus {
+  background-color: #8ec449;
+  border-color: #8ec449;
+}
+.wp-theme-4 .navbar-wp .navbar-toggle:hover .icon-bar,
+.wp-theme-4 .navbar-wp .navbar-toggle:focus .icon-bar {
+  background-color: #FFF;
+}
+.wp-theme-4 .navbar-wp .navbar-toggle:hover .icon-custom,
+.wp-theme-4 .navbar-wp .navbar-toggle:focus .icon-custom {
+  color: #FFF;
+}
+.wp-theme-4 .navbar-wp .navbar-toggle-aside-menu {
+  padding: 8px 10px 2px 10px;
+}
+.wp-theme-4 .navbar-wp .navbar-collapse,
+.wp-theme-4 .navbar-wp .navbar-form {
+  border-color: #e7e7e7;
+}
+.wp-theme-4 .navbar-wp .navbar-nav > .dropdown > a:hover .caret,
+.wp-theme-4 .navbar-wp .navbar-nav > .dropdown > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu {
+  min-width: 220px;
+  background: #FFF;
+  border: 0;
+  border-top: 1px solid #8ec449;
+  border-bottom: 3px solid #8ec449;
+  border-radius: 0;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu > li {
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu > li:last-child {
+  border: 0;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu > li > a {
+  color: #333;
+  padding: 8px 15px;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu > li > a:hover {
+  background: #8ec449;
+  color: #FFF;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu label.checkbox {
+  color: #333;
+}
+.wp-theme-4 .navbar-wp .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu-user {
+  border: 1px solid #e0eded;
+  border-top-color: transparent;
+}
+.wp-theme-4 .navbar-wp .dropdown-menu-user {
+  background: #fff;
+}
+.wp-theme-4 .navbar-wp .navbar-right .dropdown-menu-user {
+  background: #fff;
+  border-color: transparent;
+}
+.wp-theme-4 .navbar-wp .navbar-right .social-link {
+  width: 40px;
+  height: 40px;
+  line-height: 20px;
+  text-align: center;
+  padding: 10px;
+  margin: 18px 0;
+  border-radius: 100%;
+}
+.wp-theme-4 .navbar-wp .navbar-right .social-link.facebook:hover {
+  background: #43609c;
+  color: #fff;
+}
+.wp-theme-4 .navbar-wp .navbar-right .social-link.pinterest:hover {
+  background: #cb2027;
+  color: #fff;
+}
+.wp-theme-4 .navbar-wp .navbar-right .social-link.twitter:hover {
+  background: #62addb;
+  color: #fff;
+}
+.wp-theme-4 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-4 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-4 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-4 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > .open > a,
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover,
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus {
+  color: #FFF;
+  background-color: #2c2c2c;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > .open > a .caret,
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover .caret,
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:focus {
+  background: none;
+  color: #8ec449;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  bottom: 100%;
+  right: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-right: -35px;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  bottom: 100%;
+  left: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-left: -35px;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu {
+  min-width: 220px;
+  background: #2c2c2c;
+  border: 0;
+  border-top: 0;
+  border-bottom: 0;
+  border-radius: 0;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu > li {
+  border-bottom: 1px solid #262626;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu > li > a {
+  color: #fff;
+  padding: 8px 15px;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu > li > a:hover {
+  background: #8ec449;
+  color: #FFF;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox {
+  color: #fff;
+}
+.wp-theme-4 .navbar-wp.navbar-contrasted .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-4 .dropdown-submenu {
+  position: relative;
+}
+.wp-theme-4 .dropdown-submenu > .dropdown-menu {
+  top: -5px;
+  left: 100%;
+  margin-top: 0;
+  margin-left: -1px;
+}
+.wp-theme-4 .dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+.wp-theme-4 .dropdown-submenu > a:after {
+  display: block;
+  content: " ";
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 3px 0 3px 3px;
+  border-left-color: #ccc;
+  margin-top: 5px;
+  margin-right: -6px;
+}
+.wp-theme-4 .dropdown-submenu:hover > a:after {
+  border-left-color: #fff;
+}
+.wp-theme-4 .dropdown-submenu.pull-left {
+  float: none;
+}
+.wp-theme-4 .dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+}
+.wp-theme-4 .nav > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-4 .nav > ul > li {
+  border-bottom: 1px solid #333;
+}
+.wp-theme-4 .nav > ul > li > a {
+  display: block;
+  padding: 10px 15px;
+  font-size: 14px;
+  color: #fff;
+}
+.wp-theme-4 .nav > ul > li > a:hover {
+  text-decoration: none;
+  color: #8ec449;
+  background: #292929;
+}
+.wp-theme-4 .nav > ul > li > a > i {
+  margin-right: 5px;
+}
+.wp-theme-4 .lw .pg-opt {
+  border-bottom: 1px solid #e0eded;
+  background: #fcfcfc;
+}
+.wp-theme-4 .ld .pg-opt {
+  border-bottom: 1px solid #444;
+  background: #111;
+}
+.wp-theme-4 .pg-opt.fixed {
+  width: 100%;
+  position: fixed;
+  top: 0px;
+  background: rgba(250, 250, 250, 0.9);
+  border-bottom: 1px solid #e0eded;
+  z-index: 900;
+}
+.wp-theme-4 .pg-opt h2 {
+  margin: 0;
+  padding: 14px 0;
+  font-size: 22px;
+  line-height: 100%;
+}
+.wp-theme-4 .pg-opt.fixed h2 {
+  margin-bottom: 15px;
+}
+.wp-theme-4 .pg-opt hr {
+  margin: 0;
+  border-top-color: #dde1e6;
+  -webkit-box-shadow: 0 1px 0 #fbfbfc;
+  -moz-box-shadow: 0 1px 0 #fbfbfc;
+  box-shadow: 0 1px 0 #fbfbfc;
+}
+.wp-theme-4 .pg-opt.fixed hr {
+  display: none;
+}
+.wp-theme-4 .pg-opt .breadcrumb {
+  float: right;
+  margin: 0;
+  padding: 16px 0;
+  background: none;
+  border-radius: 0;
+}
+.wp-theme-4 .pg-opt .breadcrumb a {
+  color: #8ec449;
+}
+@media only screen and (max-width: 767px) {
+  .wp-theme-4 .pg-opt .pg-nav {
+    float: left;
+    margin-bottom: 10px;
+  }
+  .wp-theme-4 .pg-opt h2 {
+    padding: 20px 0 0 0;
+  }
+}
+.wp-theme-4 .page-header {
+  margin: 0;
+  border: 0;
+}
+.wp-theme-4 .page-header p {
+  font-size: 16px;
+}
+.wp-theme-4 .w-box {
+  margin: 0 0 15px 0;
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+  border: 1px solid #e0eded;
+}
+.wp-theme-4 .w-box:before,
+.wp-theme-4 .w-box:after {
+  display: table;
+  content: "";
+}
+.wp-theme-4 .w-box:after {
+  clear: both;
+}
+.wp-theme-4 .w-box h1 {
+  margin: 0;
+  padding: 10px 15px;
+  font-weight: 500;
+  font-size: 20px;
+}
+.wp-theme-4 .lw .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #333;
+}
+.wp-theme-4 .ld .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #fff;
+}
+.wp-theme-4 .w-box.inner h2 {
+  padding: 10px 0;
+}
+.wp-theme-4 .w-box small {
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+.wp-theme-4 .w-box p {
+  margin: 6px 0;
+  padding: 0 15px;
+  padding-bottom: 8px;
+}
+.wp-theme-4 .w-box time {
+  display: block;
+  padding: 8px 15px 0 15px;
+}
+.wp-theme-4 .w-box .w-footer {
+  padding: 10px 15px;
+  border-top: 1px solid #f1f1f1;
+}
+.wp-theme-4 .w-box .w-footer:before,
+.wp-theme-4 .w-box .w-footer:after {
+  display: table;
+  content: "";
+}
+.wp-theme-4 .w-box .w-footer:after {
+  clear: both;
+}
+.wp-theme-4 .w-box .w-footer small {
+  font-size: 12px;
+}
+.wp-theme-4 .w-box .w-box-parent {
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+}
+.wp-theme-4 .w-box .date-over {
+  padding: 10px;
+  background: #ffffff;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  text-align: center;
+  font-weight: normal;
+}
+.wp-theme-4 .w-box .date-over.small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.wp-theme-4 .w-box .date-over strong {
+  font-size: 12px;
+  display: block;
+  font-weight: normal;
+}
+.wp-theme-4 .w-box.dark {
+  background: #333;
+}
+.wp-theme-4 .w-box.dark h2 {
+  color: #fff;
+}
+.wp-theme-4 .w-box.white h2 {
+  border-bottom: 0;
+  text-align: center;
+}
+.wp-theme-4 .w-box.white .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.wp-theme-4 .lw .w-box.white {
+  background: #FFF;
+}
+.wp-theme-4 .lw .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-4 .ld .w-box.white {
+  background: #202020;
+  border: 1px solid #444;
+}
+.wp-theme-4 .ld .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-4 .w-box.w-box-inverse .thmb-img i {
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  font-size: 34px;
+  line-height: 100px;
+  text-align: center;
+}
+.wp-theme-4 .lw .w-box.w-box-inverse .thmb-img i {
+  background: #fcfcfc;
+  color: #8ec449;
+}
+.wp-theme-4 .ld .w-box.w-box-inverse .thmb-img i {
+  background: #363636;
+  color: #fff;
+}
+.wp-theme-4 .w-box.w-box-inverse .thmb-img:hover i {
+  background: #8ec449;
+  color: #FFF;
+}
+.wp-theme-4 .c-box {
+  border: 1px solid #8ec449;
+}
+.wp-theme-4 .c-box .c-box-header {
+  padding: 10px 15px;
+  background: #8ec449;
+  color: #fff;
+  font-size: 16px;
+  text-transform: capitalize;
+}
+.wp-theme-4 .c-box .table {
+  margin: 0;
+}
+.wp-theme-4 .ld .w-section h4,
+.wp-theme-4 .ld .w-section h3,
+.wp-theme-4 .ld .w-section h2 {
+  color: #fff;
+}
+.wp-theme-4 .w-section .aside-feature {
+  margin: 10px;
+  cursor: default;
+}
+.wp-theme-4 .w-section .aside-feature .icon-feature {
+  font-size: 68px;
+  margin-top: 10px;
+  text-align: center;
+  display: block;
+}
+.wp-theme-4 .w-section .aside-feature:hover .icon-feature,
+.wp-theme-4 .w-section .aside-feature:hover h4 {
+  color: #8ec449;
+}
+.wp-theme-4 .w-section .aside-feature .img-feature {
+  margin-top: 4px;
+  display: block;
+}
+.wp-theme-4 .w-section .aside-feature .img-feature img {
+  width: 78px;
+}
+.wp-theme-4 .layer-slider-wrapper {
+  max-height: 500px;
+  overflow: hidden;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-4 .layer-slider-wrapper .title {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-4 .layer-slider-wrapper .title.title-base {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #FFF;
+  background: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-4 .layer-slider-wrapper .title.title-dark {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-4 .layer-slider-wrapper .subtitle {
+  font-size: 22px;
+  line-height: 30px;
+  color: #8ec449;
+  text-transform: capitalize;
+}
+.wp-theme-4 .layer-slider-wrapper .list-item {
+  font-size: 18px;
+  line-height: 30px;
+  padding-left: 30px;
+  color: #8ec449;
+  text-transform: capitalize;
+}
+.wp-theme-4 .layer-slider-wrapper .text-standard {
+  font-size: 16px;
+  line-height: 22px;
+}
+.wp-theme-4 .box-element {
+  padding: 20px;
+}
+.wp-theme-4 .box-element:nth-child(n+1) {
+  margin-top: 20px;
+}
+.wp-theme-4 .box-element h1 {
+  margin: 10px 0 !important;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 400;
+}
+.wp-theme-4 .box-element.box-element-bordered {
+  background: transparent !important;
+  border: 1px solid #8ec449;
+}
+.wp-theme-4 .box-element.box-element-outer {
+  padding-left: 0;
+  padding-right: 0;
+}
+.wp-theme-4 .pricing-plans .plan-header .popular-tag {
+  background: #333;
+  border-bottom: 1px solid #FFF;
+  color: #fff;
+}
+.wp-theme-4 .carousel-2 {
+  position: relative;
+}
+.wp-theme-4 .carousel-2 .item {
+  padding: 36px 0 !important;
+}
+.wp-theme-4 .carousel-2 .carousel-indicators {
+  bottom: 0;
+}
+.wp-theme-4 .carousel-2 .carousel-indicators li {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+}
+.wp-theme-4 .carousel-2 .carousel-indicators .active {
+  background-color: #8ec449;
+}
+.wp-theme-4 .carousel-2 .img-thumbnail {
+  margin-top: 26px;
+}
+.wp-theme-4 .carousel-2 h2 {
+  font-size: 22px;
+}
+.wp-theme-4 .carousel-2 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: 10px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #8ec449;
+  opacity: 1;
+}
+.wp-theme-4 .carousel-2 .carousel-nav a:hover {
+  background: #8ec449 !important;
+  color: #fff;
+}
+.wp-theme-4 .carousel-2 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-4 .carousel-2 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-4 .carousel-2 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  font-size: 22px;
+  margin-top: -11px;
+}
+.wp-theme-4 .carousel-2 .carousel-control.left i {
+  left: 18px;
+}
+.wp-theme-4 .carousel-2 .carousel-control.right i {
+  right: 18px;
+}
+.wp-theme-4 .carousel-3 {
+  position: relative;
+}
+.wp-theme-4 .carousel-3 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: -50px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #8ec449;
+  opacity: 1;
+}
+.wp-theme-4 .carousel-3 .carousel-nav a:hover {
+  background: #8ec449 !important;
+  color: #fff;
+}
+.wp-theme-4 .carousel-3 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-4 .carousel-3 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-4 .carousel-3 .carousel-nav a:hover {
+  background: #FFF;
+}
+.wp-theme-4 .carousel-testimonials {
+  position: relative;
+  border: 1px solid #e0eded;
+}
+.wp-theme-4 .like-button .button {
+  display: block;
+  text-align: right;
+  padding-top: 10px;
+  color: #ddd;
+}
+.wp-theme-4 .like-button .button i {
+  font-size: 20px;
+  color: #ddd;
+}
+.wp-theme-4 .like-button .button.liked i {
+  color: #8ec449;
+}
+.wp-theme-4 .like-button .count {
+  display: block;
+  text-align: right;
+  position: relative;
+  top: -7px;
+}
+.wp-theme-4 .like-button.inline .button {
+  display: inline-block;
+  padding: 0;
+}
+.wp-theme-4 .like-button.inline .count {
+  display: inline-block;
+  top: -2px;
+}
+.wp-theme-4 .like-button.inline .count small {
+  font-size: 13px;
+}
+.wp-theme-4 .side-like-box {
+  text-align: center;
+  padding: 5px 5px 0 5px;
+  margin-top: 10px;
+}
+.wp-theme-4 .side-like-box .button {
+  text-align: center;
+  padding: 0;
+}
+.wp-theme-4 .side-like-box .count {
+  text-align: center;
+}
+.wp-theme-4 .side-like-box i {
+  font-size: 24px;
+}
+.wp-theme-4 ul.list-listings {
+  margin: 0 0 20px 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-4 ul.list-listings li {
+  margin-bottom: 30px;
+  border: 1px solid #f3f3f3;
+  overflow: hidden;
+}
+.wp-theme-4 ul.list-listings li.featured {
+  border-color: #8ec449;
+}
+.wp-theme-4 ul.list-listings li:before,
+.wp-theme-4 ul.list-listings li:after {
+  content: "";
+  display: table;
+}
+.wp-theme-4 ul.list-listings li:after {
+  clear: both;
+}
+.wp-theme-4 ul.list-listings .listing-header {
+  clear: both;
+  padding: 8px 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.wp-theme-4 ul.list-listings .listing-image {
+  width: 25%;
+  height: 150px;
+  float: left;
+  overflow: hidden;
+}
+.wp-theme-4 ul.list-listings .listing-body {
+  width: 50%;
+  height: 150px;
+  padding: 15px;
+  float: left;
+  background: #fcfcfc;
+  border-right: 1px solid #fcfcfc;
+}
+.wp-theme-4 ul.list-listings .listing-body h3 {
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 25px;
+}
+.wp-theme-4 ul.list-listings .listing-body h4 {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 22px;
+}
+.wp-theme-4 ul.list-listings .listing-actions {
+  width: 25%;
+  height: 110px;
+  padding-top: 40px;
+  float: left;
+  text-align: center;
+}
+.wp-theme-4 ul.list-listings .listing-actions .btn {
+  margin-top: 6px;
+}
+.wp-theme-4 ul.list-check {
+  list-style: none;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+}
+.wp-theme-4 ul.list-check li {
+  padding: 4px 0;
+  margin: 0;
+  display: block;
+  width: 100%;
+}
+.wp-theme-4 ul.list-check li i {
+  color: #8ec449;
+  font-style: normal;
+  margin-right: 4px;
+}
+.wp-theme-4 ul.list-check li span {
+  font-size: 14px;
+}
+.wp-theme-4 ul.categories {
+  list-style: none;
+  margin: 0;
+  padding: 0 !important;
+  border: 1px solid #e0eded;
+  overflow: hidden;
+}
+.wp-theme-4 ul.categories li {
+  border-bottom: 1px solid #e0eded;
+  position: reltive;
+}
+.wp-theme-4 ul.categories li:last-child {
+  border: 0;
+}
+.wp-theme-4 ul.categories li a {
+  display: block;
+  padding: 10px 15px;
+}
+.wp-theme-4 ul.categories li a:after {
+  font-family: 'FontAwesome';
+  content: "\f105";
+  position: relative;
+  top: 0;
+  float: right;
+}
+.wp-theme-4 ul.categories li a:hover {
+  background: #8ec449;
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-4 ul.categories li a i {
+  display: inline-block;
+  vertical-align: middle;
+  padding-right: 5px;
+  font-style: normal;
+  color: #999;
+  font-size: 11px;
+}
+.wp-theme-4 ul.categories li a:hover i {
+  color: #FFF;
+}
+.wp-theme-4 .timeline .year {
+  width: 100%;
+  background: #333;
+  padding: 8px 10px;
+  margin: 20px auto 40px !important;
+  font-size: 20px;
+}
+.wp-theme-4 .timeline .year {
+  border-radius: 3px;
+}
+.wp-theme-4 .timeline .event {
+  padding: 0;
+  border: 1px solid #e0eded;
+  border-radius: 0;
+}
+.wp-theme-4 .timeline .event:nth-child(2n):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -6.8% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #8ec449;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-4 .timeline .event:nth-child(2n-1):after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #FFF;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+}
+.wp-theme-4 .timeline .event:nth-child(2n-1):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -6.5% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #8ec449;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-4 .timeline .event-date {
+  margin: 0;
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+  text-align: left;
+  padding: 10px 10px;
+  font-weight: 500;
+  font-size: 14px;
+}
+.wp-theme-4 .timeline .event:nth-child(2n) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-4 .timeline .event:nth-child(2n) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  right: -13px;
+  width: 0;
+  height: 0;
+  border-left: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-4 .timeline .event:nth-child(2n-1) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-4 .timeline .event:nth-child(2n-1) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  left: -13px;
+  width: 0;
+  height: 0;
+  border-right: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-4 .timeline .event-date small {
+  display: block;
+  font-size: 12px;
+  color: #a1a1a1;
+  font-weight: normal;
+}
+.wp-theme-4 .timeline .event-date i {
+  margin-right: 7px;
+}
+.wp-theme-4 .timeline .event-body {
+  background: #f8f8f8;
+}
+.wp-theme-4 .timeline .event-footer {
+  margin: 0;
+  text-align: left;
+  padding: 8px 10px;
+  background: none;
+  border-top: 1px solid #e0eded;
+}
+.wp-theme-4 .timeline .event-footer:after,
+.wp-theme-4 .timeline .event-footer:before {
+  display: table;
+  content: " ";
+}
+.wp-theme-4 .timeline .event-footer:after {
+  clear: both;
+}
+.wp-theme-4 .timeline .event img {
+  margin: 0;
+}
+.wp-theme-4 .timeline p {
+  padding: 20px 10px;
+  text-align: left;
+}
+.wp-theme-4 .timeline iframe {
+  margin: 10px 0 0 0;
+}
+.wp-theme-4 #toTop {
+  display: none;
+  text-decoration: none;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+  border: none;
+  text-indent: 100%;
+  background: #555;
+  border-radius: 3px;
+}
+.wp-theme-4 #toTopHover {
+  background: #8ec449;
+  width: 40px;
+  height: 40px;
+  display: block;
+  overflow: hidden;
+  float: left;
+  opacity: 0;
+  -moz-opacity: 0;
+  filter: alpha(opacity=0);
+}
+.wp-theme-4 #toTop:active,
+.wp-theme-4 #toTop:focus {
+  outline: none;
+}
+.wp-theme-4 #toTop:before {
+  font-family: 'FontAwesome';
+  content: "\f106";
+  color: #ffffff;
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  line-height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  text-indent: 0;
+}
+.wp-theme-4 .widget.tags-wr {
+  padding-bottom: 15px;
+}
+.wp-theme-4 .tags-list:before,
+.wp-theme-4 .tags-list:after {
+  display: table;
+  content: "";
+}
+.wp-theme-4 .tags-list:after {
+  clear: both;
+}
+.wp-theme-4 .tags-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.wp-theme-4 .tags-list li {
+  border: 1px solid #8ec449;
+  background: #FFF;
+  padding: 5px;
+  float: left;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  color: #8ec449;
+  font-size: 12px;
+}
+.wp-theme-4 .tags-list li a {
+  color: #8ec449;
+  margin-left: 4px;
+}
+.wp-theme-4 .tags-list li:hover {
+  background: #8ec449;
+  color: #FFF;
+}
+.wp-theme-4 .tags-list li:hover a {
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-5 {
+  /* LAYER SLIDER CUSTOMS */
+  /* BOX ELEMENTS */
+  /* TAG CLOUD */
+}
+.wp-theme-5 .btn {
+  font-weight: normal;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+.wp-theme-5 .btn i {
+  margin-right: 4px;
+}
+.wp-theme-5 .btn-lg {
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 3px;
+}
+.wp-theme-5 .btn-lg i {
+  font-size: 24px;
+  position: relative;
+  top: 3px;
+}
+.wp-theme-5 .btn-xs {
+  padding: 4px 10px;
+}
+.wp-theme-5 .btn-one {
+  background-color: none;
+  border: 2px solid #FFF;
+  color: #FFF;
+}
+.wp-theme-5 .btn-one:hover,
+.wp-theme-5 .btn-one:focus,
+.wp-theme-5 .btn-one:active,
+.wp-theme-5 .btn-one.active,
+.wp-theme-5 .open .dropdown-toggle.btn-one {
+  color: #f1c40f;
+  background-color: #FFF;
+  border-color: #FFF;
+}
+.wp-theme-5 .btn-one:active,
+.wp-theme-5 .btn-one.active,
+.wp-theme-5 .open .dropdown-toggle.btn-one {
+  background-image: none;
+}
+.wp-theme-5 .btn-two {
+  color: #ffffff;
+  background-color: #f1c40f;
+  border: 1px solid;
+  border-color: #e7ba05;
+}
+.wp-theme-5 .btn-two:hover,
+.wp-theme-5 .btn-two:focus,
+.wp-theme-5 .btn-two:active,
+.wp-theme-5 .btn-two.active,
+.wp-theme-5 .open .dropdown-toggle.btn-two {
+  color: #ffffff;
+  background-color: #ddb000;
+  border-color: #ddb000;
+}
+.wp-theme-5 .btn-two:active,
+.wp-theme-5 .btn-two.active,
+.wp-theme-5 .open .dropdown-toggle.btn-two {
+  background-image: none;
+}
+.wp-theme-5 .btn-three {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid;
+  border-color: #292929;
+}
+.wp-theme-5 .btn-three:hover,
+.wp-theme-5 .btn-three:focus,
+.wp-theme-5 .btn-three:active,
+.wp-theme-5 .btn-three.active,
+.wp-theme-5 .open .dropdown-toggle.btn-three {
+  color: #ffffff;
+  background-color: #1f1f1f;
+  border-color: #1f1f1f;
+}
+.wp-theme-5 .btn-three:active,
+.wp-theme-5 .btn-three.active,
+.wp-theme-5 .open .dropdown-toggle.btn-three {
+  background-image: none;
+}
+.wp-theme-5 .btn-four {
+  background-color: none;
+  border: 2px solid #f1c40f;
+  color: #f1c40f;
+}
+.wp-theme-5 .btn-four:hover,
+.wp-theme-5 .btn-four:focus,
+.wp-theme-5 .btn-four:active,
+.wp-theme-5 .btn-four.active,
+.wp-theme-5 .open .dropdown-toggle.btn-four {
+  color: #FFF;
+  background-color: #f1c40f;
+}
+.wp-theme-5 .btn-four:active,
+.wp-theme-5 .btn-four.active,
+.wp-theme-5 .open .dropdown-toggle.btn-four {
+  background-image: none;
+}
+.wp-theme-5 h1,
+.wp-theme-5 h2,
+.wp-theme-5 h3,
+.wp-theme-5 h4,
+.wp-theme-5 h5,
+.wp-theme-5 h6 {
+  font-family: "Roboto", sans-serif !important;
+}
+.wp-theme-5 p {
+  line-height: 22px;
+}
+.wp-theme-5 a {
+  color: #616161;
+  cursor: pointer;
+}
+.wp-theme-5 a:hover {
+  color: #f1c40f;
+  text-decoration: none;
+  -o-transition: .3s;
+  -ms-transition: .3s;
+  -moz-transition: .3s;
+  -webkit-transition: .3s;
+  transition: .35s;
+}
+.wp-theme-5 .bg-2 {
+  background: #f1c40f;
+  color: #FFF;
+}
+.wp-theme-5 .lw .bg-5 {
+  background: #fcfcfc;
+  border-top: 1px solid #e0eded;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-5 .ld .bg-5 {
+  background: #363636;
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-5 .lw .bg-3 {
+  background: #fff;
+  color: #616161;
+}
+.wp-theme-5 .ld .bg-3 {
+  background: #202020;
+  color: #888;
+}
+.wp-theme-5 .bg-4 {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-5 .dark {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-5 .red {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-5 .orange {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-5 .green {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-5 .blue {
+  background: #3498db;
+  color: #FFF;
+}
+.wp-theme-5 .light {
+  background: #fff;
+  color: #616161 !important;
+}
+.wp-theme-5 .blockquote-1:hover {
+  border-color: #f1c40f;
+}
+.wp-theme-5 .blockquote-1 p {
+  font-size: 13px;
+}
+.wp-theme-5 .section-title {
+  display: inline-block;
+  border-bottom: 1px solid #333;
+  margin: 0 0 15px 0;
+  padding: 0 0 5px 0;
+  font-size: 20px;
+  font-weight: 500;
+  text-transform: capitalize;
+  position: relative;
+  overflow: hidden;
+}
+.wp-theme-5 .lw .section-title {
+  color: #333;
+}
+.wp-theme-5 .ld .section-title {
+  color: #fff;
+}
+.wp-theme-5 .section-title.white {
+  color: #fff;
+  border-bottom: 1px solid #fff;
+}
+.wp-theme-5 .navbar-wp {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  z-index: 1000;
+}
+.wp-theme-5 .lw .navbar-wp {
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-5 .ld .navbar-wp {
+  background: #181818;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-5 .ld .sticky-wrapper .navbar-wp {
+  background: rgba(24, 24, 24, 0.85);
+  border-bottom: 1px solid #444;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > li > a {
+  padding: 28px 16px;
+  margin-right: 0;
+  font-size: 15px;
+  font-weight: normal;
+}
+.wp-theme-5 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-5 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-5 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-5 .lw .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #333;
+}
+.wp-theme-5 .lw .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-5 .lw .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #f1c40f;
+}
+.wp-theme-5 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-5 .ld .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #fff;
+}
+.wp-theme-5 .ld .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-5 .ld .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #f1c40f;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > .active > a,
+.wp-theme-5 .navbar-wp .navbar-nav > .active > a:hover,
+.wp-theme-5 .navbar-wp .navbar-nav > .active > a:focus {
+  color: #fff !important;
+  background-color: #f1c40f;
+  border-radius: 0;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > .disabled > a,
+.wp-theme-5 .navbar-wp .navbar-nav > .disabled > a:hover,
+.wp-theme-5 .navbar-wp .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a,
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a:hover,
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a:focus {
+  color: #FFF !important;
+  background-color: #f1c40f;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a .caret,
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a:hover .caret,
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle,
+.wp-theme-5 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-5 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:focus {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+  color: #f1c40f;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle,
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:hover,
+.wp-theme-5 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:focus {
+  color: #f1c40f !important;
+  background-color: none;
+}
+.wp-theme-5 .navbar-wp .navbar-toggle {
+  border-color: #333;
+  margin-top: 20px;
+}
+.wp-theme-5 .navbar-wp .navbar-toggle .icon-bar {
+  background-color: #4c4c4c;
+}
+.wp-theme-5 .navbar-wp .navbar-toggle .icon-custom {
+  font-size: 18px;
+}
+.wp-theme-5 .navbar-wp .navbar-toggle:hover,
+.wp-theme-5 .navbar-wp .navbar-toggle:focus {
+  background-color: #f1c40f;
+  border-color: #f1c40f;
+}
+.wp-theme-5 .navbar-wp .navbar-toggle:hover .icon-bar,
+.wp-theme-5 .navbar-wp .navbar-toggle:focus .icon-bar {
+  background-color: #FFF;
+}
+.wp-theme-5 .navbar-wp .navbar-toggle:hover .icon-custom,
+.wp-theme-5 .navbar-wp .navbar-toggle:focus .icon-custom {
+  color: #FFF;
+}
+.wp-theme-5 .navbar-wp .navbar-toggle-aside-menu {
+  padding: 8px 10px 2px 10px;
+}
+.wp-theme-5 .navbar-wp .navbar-collapse,
+.wp-theme-5 .navbar-wp .navbar-form {
+  border-color: #e7e7e7;
+}
+.wp-theme-5 .navbar-wp .navbar-nav > .dropdown > a:hover .caret,
+.wp-theme-5 .navbar-wp .navbar-nav > .dropdown > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu {
+  min-width: 220px;
+  background: #FFF;
+  border: 0;
+  border-top: 1px solid #f1c40f;
+  border-bottom: 3px solid #f1c40f;
+  border-radius: 0;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu > li {
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu > li:last-child {
+  border: 0;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu > li > a {
+  color: #333;
+  padding: 8px 15px;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu > li > a:hover {
+  background: #f1c40f;
+  color: #FFF;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu label.checkbox {
+  color: #333;
+}
+.wp-theme-5 .navbar-wp .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu-user {
+  border: 1px solid #e0eded;
+  border-top-color: transparent;
+}
+.wp-theme-5 .navbar-wp .dropdown-menu-user {
+  background: #fff;
+}
+.wp-theme-5 .navbar-wp .navbar-right .dropdown-menu-user {
+  background: #fff;
+  border-color: transparent;
+}
+.wp-theme-5 .navbar-wp .navbar-right .social-link {
+  width: 40px;
+  height: 40px;
+  line-height: 20px;
+  text-align: center;
+  padding: 10px;
+  margin: 18px 0;
+  border-radius: 100%;
+}
+.wp-theme-5 .navbar-wp .navbar-right .social-link.facebook:hover {
+  background: #43609c;
+  color: #fff;
+}
+.wp-theme-5 .navbar-wp .navbar-right .social-link.pinterest:hover {
+  background: #cb2027;
+  color: #fff;
+}
+.wp-theme-5 .navbar-wp .navbar-right .social-link.twitter:hover {
+  background: #62addb;
+  color: #fff;
+}
+.wp-theme-5 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-5 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-5 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-5 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > .open > a,
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover,
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus {
+  color: #FFF;
+  background-color: #2c2c2c;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > .open > a .caret,
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover .caret,
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:focus {
+  background: none;
+  color: #f1c40f;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  bottom: 100%;
+  right: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-right: -35px;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  bottom: 100%;
+  left: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-left: -35px;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu {
+  min-width: 220px;
+  background: #2c2c2c;
+  border: 0;
+  border-top: 0;
+  border-bottom: 0;
+  border-radius: 0;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu > li {
+  border-bottom: 1px solid #262626;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu > li > a {
+  color: #fff;
+  padding: 8px 15px;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu > li > a:hover {
+  background: #f1c40f;
+  color: #FFF;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox {
+  color: #fff;
+}
+.wp-theme-5 .navbar-wp.navbar-contrasted .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-5 .dropdown-submenu {
+  position: relative;
+}
+.wp-theme-5 .dropdown-submenu > .dropdown-menu {
+  top: -5px;
+  left: 100%;
+  margin-top: 0;
+  margin-left: -1px;
+}
+.wp-theme-5 .dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+.wp-theme-5 .dropdown-submenu > a:after {
+  display: block;
+  content: " ";
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 3px 0 3px 3px;
+  border-left-color: #ccc;
+  margin-top: 5px;
+  margin-right: -6px;
+}
+.wp-theme-5 .dropdown-submenu:hover > a:after {
+  border-left-color: #fff;
+}
+.wp-theme-5 .dropdown-submenu.pull-left {
+  float: none;
+}
+.wp-theme-5 .dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+}
+.wp-theme-5 .nav > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-5 .nav > ul > li {
+  border-bottom: 1px solid #333;
+}
+.wp-theme-5 .nav > ul > li > a {
+  display: block;
+  padding: 10px 15px;
+  font-size: 14px;
+  color: #fff;
+}
+.wp-theme-5 .nav > ul > li > a:hover {
+  text-decoration: none;
+  color: #f1c40f;
+  background: #292929;
+}
+.wp-theme-5 .nav > ul > li > a > i {
+  margin-right: 5px;
+}
+.wp-theme-5 .lw .pg-opt {
+  border-bottom: 1px solid #e0eded;
+  background: #fcfcfc;
+}
+.wp-theme-5 .ld .pg-opt {
+  border-bottom: 1px solid #444;
+  background: #111;
+}
+.wp-theme-5 .pg-opt.fixed {
+  width: 100%;
+  position: fixed;
+  top: 0px;
+  background: rgba(250, 250, 250, 0.9);
+  border-bottom: 1px solid #e0eded;
+  z-index: 900;
+}
+.wp-theme-5 .pg-opt h2 {
+  margin: 0;
+  padding: 14px 0;
+  font-size: 22px;
+  line-height: 100%;
+}
+.wp-theme-5 .pg-opt.fixed h2 {
+  margin-bottom: 15px;
+}
+.wp-theme-5 .pg-opt hr {
+  margin: 0;
+  border-top-color: #dde1e6;
+  -webkit-box-shadow: 0 1px 0 #fbfbfc;
+  -moz-box-shadow: 0 1px 0 #fbfbfc;
+  box-shadow: 0 1px 0 #fbfbfc;
+}
+.wp-theme-5 .pg-opt.fixed hr {
+  display: none;
+}
+.wp-theme-5 .pg-opt .breadcrumb {
+  float: right;
+  margin: 0;
+  padding: 16px 0;
+  background: none;
+  border-radius: 0;
+}
+.wp-theme-5 .pg-opt .breadcrumb a {
+  color: #f1c40f;
+}
+@media only screen and (max-width: 767px) {
+  .wp-theme-5 .pg-opt .pg-nav {
+    float: left;
+    margin-bottom: 10px;
+  }
+  .wp-theme-5 .pg-opt h2 {
+    padding: 20px 0 0 0;
+  }
+}
+.wp-theme-5 .page-header {
+  margin: 0;
+  border: 0;
+}
+.wp-theme-5 .page-header p {
+  font-size: 16px;
+}
+.wp-theme-5 .w-box {
+  margin: 0 0 15px 0;
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+  border: 1px solid #e0eded;
+}
+.wp-theme-5 .w-box:before,
+.wp-theme-5 .w-box:after {
+  display: table;
+  content: "";
+}
+.wp-theme-5 .w-box:after {
+  clear: both;
+}
+.wp-theme-5 .w-box h1 {
+  margin: 0;
+  padding: 10px 15px;
+  font-weight: 500;
+  font-size: 20px;
+}
+.wp-theme-5 .lw .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #333;
+}
+.wp-theme-5 .ld .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #fff;
+}
+.wp-theme-5 .w-box.inner h2 {
+  padding: 10px 0;
+}
+.wp-theme-5 .w-box small {
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+.wp-theme-5 .w-box p {
+  margin: 6px 0;
+  padding: 0 15px;
+  padding-bottom: 8px;
+}
+.wp-theme-5 .w-box time {
+  display: block;
+  padding: 8px 15px 0 15px;
+}
+.wp-theme-5 .w-box .w-footer {
+  padding: 10px 15px;
+  border-top: 1px solid #f1f1f1;
+}
+.wp-theme-5 .w-box .w-footer:before,
+.wp-theme-5 .w-box .w-footer:after {
+  display: table;
+  content: "";
+}
+.wp-theme-5 .w-box .w-footer:after {
+  clear: both;
+}
+.wp-theme-5 .w-box .w-footer small {
+  font-size: 12px;
+}
+.wp-theme-5 .w-box .w-box-parent {
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+}
+.wp-theme-5 .w-box .date-over {
+  padding: 10px;
+  background: #ffffff;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  text-align: center;
+  font-weight: normal;
+}
+.wp-theme-5 .w-box .date-over.small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.wp-theme-5 .w-box .date-over strong {
+  font-size: 12px;
+  display: block;
+  font-weight: normal;
+}
+.wp-theme-5 .w-box.dark {
+  background: #333;
+}
+.wp-theme-5 .w-box.dark h2 {
+  color: #fff;
+}
+.wp-theme-5 .w-box.white h2 {
+  border-bottom: 0;
+  text-align: center;
+}
+.wp-theme-5 .w-box.white .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.wp-theme-5 .lw .w-box.white {
+  background: #FFF;
+}
+.wp-theme-5 .lw .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-5 .ld .w-box.white {
+  background: #202020;
+  border: 1px solid #444;
+}
+.wp-theme-5 .ld .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-5 .w-box.w-box-inverse .thmb-img i {
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  font-size: 34px;
+  line-height: 100px;
+  text-align: center;
+}
+.wp-theme-5 .lw .w-box.w-box-inverse .thmb-img i {
+  background: #fcfcfc;
+  color: #f1c40f;
+}
+.wp-theme-5 .ld .w-box.w-box-inverse .thmb-img i {
+  background: #363636;
+  color: #fff;
+}
+.wp-theme-5 .w-box.w-box-inverse .thmb-img:hover i {
+  background: #f1c40f;
+  color: #FFF;
+}
+.wp-theme-5 .c-box {
+  border: 1px solid #f1c40f;
+}
+.wp-theme-5 .c-box .c-box-header {
+  padding: 10px 15px;
+  background: #f1c40f;
+  color: #fff;
+  font-size: 16px;
+  text-transform: capitalize;
+}
+.wp-theme-5 .c-box .table {
+  margin: 0;
+}
+.wp-theme-5 .ld .w-section h4,
+.wp-theme-5 .ld .w-section h3,
+.wp-theme-5 .ld .w-section h2 {
+  color: #fff;
+}
+.wp-theme-5 .w-section .aside-feature {
+  margin: 10px;
+  cursor: default;
+}
+.wp-theme-5 .w-section .aside-feature .icon-feature {
+  font-size: 68px;
+  margin-top: 10px;
+  text-align: center;
+  display: block;
+}
+.wp-theme-5 .w-section .aside-feature:hover .icon-feature,
+.wp-theme-5 .w-section .aside-feature:hover h4 {
+  color: #f1c40f;
+}
+.wp-theme-5 .w-section .aside-feature .img-feature {
+  margin-top: 4px;
+  display: block;
+}
+.wp-theme-5 .w-section .aside-feature .img-feature img {
+  width: 78px;
+}
+.wp-theme-5 .layer-slider-wrapper {
+  max-height: 500px;
+  overflow: hidden;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-5 .layer-slider-wrapper .title {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-5 .layer-slider-wrapper .title.title-base {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #FFF;
+  background: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-5 .layer-slider-wrapper .title.title-dark {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-5 .layer-slider-wrapper .subtitle {
+  font-size: 22px;
+  line-height: 30px;
+  color: #f1c40f;
+  text-transform: capitalize;
+}
+.wp-theme-5 .layer-slider-wrapper .list-item {
+  font-size: 18px;
+  line-height: 30px;
+  padding-left: 30px;
+  color: #f1c40f;
+  text-transform: capitalize;
+}
+.wp-theme-5 .layer-slider-wrapper .text-standard {
+  font-size: 16px;
+  line-height: 22px;
+}
+.wp-theme-5 .box-element {
+  padding: 20px;
+}
+.wp-theme-5 .box-element:nth-child(n+1) {
+  margin-top: 20px;
+}
+.wp-theme-5 .box-element h1 {
+  margin: 10px 0 !important;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 400;
+}
+.wp-theme-5 .box-element.box-element-bordered {
+  background: transparent !important;
+  border: 1px solid #f1c40f;
+}
+.wp-theme-5 .box-element.box-element-outer {
+  padding-left: 0;
+  padding-right: 0;
+}
+.wp-theme-5 .pricing-plans .plan-header .popular-tag {
+  background: #333;
+  border-bottom: 1px solid #FFF;
+  color: #fff;
+}
+.wp-theme-5 .carousel-2 {
+  position: relative;
+}
+.wp-theme-5 .carousel-2 .item {
+  padding: 36px 0 !important;
+}
+.wp-theme-5 .carousel-2 .carousel-indicators {
+  bottom: 0;
+}
+.wp-theme-5 .carousel-2 .carousel-indicators li {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+}
+.wp-theme-5 .carousel-2 .carousel-indicators .active {
+  background-color: #f1c40f;
+}
+.wp-theme-5 .carousel-2 .img-thumbnail {
+  margin-top: 26px;
+}
+.wp-theme-5 .carousel-2 h2 {
+  font-size: 22px;
+}
+.wp-theme-5 .carousel-2 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: 10px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #f1c40f;
+  opacity: 1;
+}
+.wp-theme-5 .carousel-2 .carousel-nav a:hover {
+  background: #f1c40f !important;
+  color: #fff;
+}
+.wp-theme-5 .carousel-2 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-5 .carousel-2 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-5 .carousel-2 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  font-size: 22px;
+  margin-top: -11px;
+}
+.wp-theme-5 .carousel-2 .carousel-control.left i {
+  left: 18px;
+}
+.wp-theme-5 .carousel-2 .carousel-control.right i {
+  right: 18px;
+}
+.wp-theme-5 .carousel-3 {
+  position: relative;
+}
+.wp-theme-5 .carousel-3 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: -50px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #f1c40f;
+  opacity: 1;
+}
+.wp-theme-5 .carousel-3 .carousel-nav a:hover {
+  background: #f1c40f !important;
+  color: #fff;
+}
+.wp-theme-5 .carousel-3 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-5 .carousel-3 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-5 .carousel-3 .carousel-nav a:hover {
+  background: #FFF;
+}
+.wp-theme-5 .carousel-testimonials {
+  position: relative;
+  border: 1px solid #e0eded;
+}
+.wp-theme-5 .like-button .button {
+  display: block;
+  text-align: right;
+  padding-top: 10px;
+  color: #ddd;
+}
+.wp-theme-5 .like-button .button i {
+  font-size: 20px;
+  color: #ddd;
+}
+.wp-theme-5 .like-button .button.liked i {
+  color: #f1c40f;
+}
+.wp-theme-5 .like-button .count {
+  display: block;
+  text-align: right;
+  position: relative;
+  top: -7px;
+}
+.wp-theme-5 .like-button.inline .button {
+  display: inline-block;
+  padding: 0;
+}
+.wp-theme-5 .like-button.inline .count {
+  display: inline-block;
+  top: -2px;
+}
+.wp-theme-5 .like-button.inline .count small {
+  font-size: 13px;
+}
+.wp-theme-5 .side-like-box {
+  text-align: center;
+  padding: 5px 5px 0 5px;
+  margin-top: 10px;
+}
+.wp-theme-5 .side-like-box .button {
+  text-align: center;
+  padding: 0;
+}
+.wp-theme-5 .side-like-box .count {
+  text-align: center;
+}
+.wp-theme-5 .side-like-box i {
+  font-size: 24px;
+}
+.wp-theme-5 ul.list-listings {
+  margin: 0 0 20px 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-5 ul.list-listings li {
+  margin-bottom: 30px;
+  border: 1px solid #f3f3f3;
+  overflow: hidden;
+}
+.wp-theme-5 ul.list-listings li.featured {
+  border-color: #f1c40f;
+}
+.wp-theme-5 ul.list-listings li:before,
+.wp-theme-5 ul.list-listings li:after {
+  content: "";
+  display: table;
+}
+.wp-theme-5 ul.list-listings li:after {
+  clear: both;
+}
+.wp-theme-5 ul.list-listings .listing-header {
+  clear: both;
+  padding: 8px 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.wp-theme-5 ul.list-listings .listing-image {
+  width: 25%;
+  height: 150px;
+  float: left;
+  overflow: hidden;
+}
+.wp-theme-5 ul.list-listings .listing-body {
+  width: 50%;
+  height: 150px;
+  padding: 15px;
+  float: left;
+  background: #fcfcfc;
+  border-right: 1px solid #fcfcfc;
+}
+.wp-theme-5 ul.list-listings .listing-body h3 {
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 25px;
+}
+.wp-theme-5 ul.list-listings .listing-body h4 {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 22px;
+}
+.wp-theme-5 ul.list-listings .listing-actions {
+  width: 25%;
+  height: 110px;
+  padding-top: 40px;
+  float: left;
+  text-align: center;
+}
+.wp-theme-5 ul.list-listings .listing-actions .btn {
+  margin-top: 6px;
+}
+.wp-theme-5 ul.list-check {
+  list-style: none;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+}
+.wp-theme-5 ul.list-check li {
+  padding: 4px 0;
+  margin: 0;
+  display: block;
+  width: 100%;
+}
+.wp-theme-5 ul.list-check li i {
+  color: #f1c40f;
+  font-style: normal;
+  margin-right: 4px;
+}
+.wp-theme-5 ul.list-check li span {
+  font-size: 14px;
+}
+.wp-theme-5 ul.categories {
+  list-style: none;
+  margin: 0;
+  padding: 0 !important;
+  border: 1px solid #e0eded;
+  overflow: hidden;
+}
+.wp-theme-5 ul.categories li {
+  border-bottom: 1px solid #e0eded;
+  position: reltive;
+}
+.wp-theme-5 ul.categories li:last-child {
+  border: 0;
+}
+.wp-theme-5 ul.categories li a {
+  display: block;
+  padding: 10px 15px;
+}
+.wp-theme-5 ul.categories li a:after {
+  font-family: 'FontAwesome';
+  content: "\f105";
+  position: relative;
+  top: 0;
+  float: right;
+}
+.wp-theme-5 ul.categories li a:hover {
+  background: #f1c40f;
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-5 ul.categories li a i {
+  display: inline-block;
+  vertical-align: middle;
+  padding-right: 5px;
+  font-style: normal;
+  color: #999;
+  font-size: 11px;
+}
+.wp-theme-5 ul.categories li a:hover i {
+  color: #FFF;
+}
+.wp-theme-5 .timeline .year {
+  width: 100%;
+  background: #333;
+  padding: 8px 10px;
+  margin: 20px auto 40px !important;
+  font-size: 20px;
+}
+.wp-theme-5 .timeline .year {
+  border-radius: 3px;
+}
+.wp-theme-5 .timeline .event {
+  padding: 0;
+  border: 1px solid #e0eded;
+  border-radius: 0;
+}
+.wp-theme-5 .timeline .event:nth-child(2n):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -6.8% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #f1c40f;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-5 .timeline .event:nth-child(2n-1):after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #FFF;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+}
+.wp-theme-5 .timeline .event:nth-child(2n-1):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -6.5% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #f1c40f;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-5 .timeline .event-date {
+  margin: 0;
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+  text-align: left;
+  padding: 10px 10px;
+  font-weight: 500;
+  font-size: 14px;
+}
+.wp-theme-5 .timeline .event:nth-child(2n) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-5 .timeline .event:nth-child(2n) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  right: -13px;
+  width: 0;
+  height: 0;
+  border-left: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-5 .timeline .event:nth-child(2n-1) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-5 .timeline .event:nth-child(2n-1) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  left: -13px;
+  width: 0;
+  height: 0;
+  border-right: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-5 .timeline .event-date small {
+  display: block;
+  font-size: 12px;
+  color: #a1a1a1;
+  font-weight: normal;
+}
+.wp-theme-5 .timeline .event-date i {
+  margin-right: 7px;
+}
+.wp-theme-5 .timeline .event-body {
+  background: #f8f8f8;
+}
+.wp-theme-5 .timeline .event-footer {
+  margin: 0;
+  text-align: left;
+  padding: 8px 10px;
+  background: none;
+  border-top: 1px solid #e0eded;
+}
+.wp-theme-5 .timeline .event-footer:after,
+.wp-theme-5 .timeline .event-footer:before {
+  display: table;
+  content: " ";
+}
+.wp-theme-5 .timeline .event-footer:after {
+  clear: both;
+}
+.wp-theme-5 .timeline .event img {
+  margin: 0;
+}
+.wp-theme-5 .timeline p {
+  padding: 20px 10px;
+  text-align: left;
+}
+.wp-theme-5 .timeline iframe {
+  margin: 10px 0 0 0;
+}
+.wp-theme-5 #toTop {
+  display: none;
+  text-decoration: none;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+  border: none;
+  text-indent: 100%;
+  background: #555;
+  border-radius: 3px;
+}
+.wp-theme-5 #toTopHover {
+  background: #f1c40f;
+  width: 40px;
+  height: 40px;
+  display: block;
+  overflow: hidden;
+  float: left;
+  opacity: 0;
+  -moz-opacity: 0;
+  filter: alpha(opacity=0);
+}
+.wp-theme-5 #toTop:active,
+.wp-theme-5 #toTop:focus {
+  outline: none;
+}
+.wp-theme-5 #toTop:before {
+  font-family: 'FontAwesome';
+  content: "\f106";
+  color: #ffffff;
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  line-height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  text-indent: 0;
+}
+.wp-theme-5 .widget.tags-wr {
+  padding-bottom: 15px;
+}
+.wp-theme-5 .tags-list:before,
+.wp-theme-5 .tags-list:after {
+  display: table;
+  content: "";
+}
+.wp-theme-5 .tags-list:after {
+  clear: both;
+}
+.wp-theme-5 .tags-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.wp-theme-5 .tags-list li {
+  border: 1px solid #f1c40f;
+  background: #FFF;
+  padding: 5px;
+  float: left;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  color: #f1c40f;
+  font-size: 12px;
+}
+.wp-theme-5 .tags-list li a {
+  color: #f1c40f;
+  margin-left: 4px;
+}
+.wp-theme-5 .tags-list li:hover {
+  background: #f1c40f;
+  color: #FFF;
+}
+.wp-theme-5 .tags-list li:hover a {
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-6 {
+  /* LAYER SLIDER CUSTOMS */
+  /* BOX ELEMENTS */
+  /* TAG CLOUD */
+}
+.wp-theme-6 .btn {
+  font-weight: normal;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+.wp-theme-6 .btn i {
+  margin-right: 4px;
+}
+.wp-theme-6 .btn-lg {
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 3px;
+}
+.wp-theme-6 .btn-lg i {
+  font-size: 24px;
+  position: relative;
+  top: 3px;
+}
+.wp-theme-6 .btn-xs {
+  padding: 4px 10px;
+}
+.wp-theme-6 .btn-one {
+  background-color: none;
+  border: 2px solid #FFF;
+  color: #FFF;
+}
+.wp-theme-6 .btn-one:hover,
+.wp-theme-6 .btn-one:focus,
+.wp-theme-6 .btn-one:active,
+.wp-theme-6 .btn-one.active,
+.wp-theme-6 .open .dropdown-toggle.btn-one {
+  color: #d35400;
+  background-color: #FFF;
+  border-color: #FFF;
+}
+.wp-theme-6 .btn-one:active,
+.wp-theme-6 .btn-one.active,
+.wp-theme-6 .open .dropdown-toggle.btn-one {
+  background-image: none;
+}
+.wp-theme-6 .btn-two {
+  color: #ffffff;
+  background-color: #d35400;
+  border: 1px solid;
+  border-color: #c94a00;
+}
+.wp-theme-6 .btn-two:hover,
+.wp-theme-6 .btn-two:focus,
+.wp-theme-6 .btn-two:active,
+.wp-theme-6 .btn-two.active,
+.wp-theme-6 .open .dropdown-toggle.btn-two {
+  color: #ffffff;
+  background-color: #bf4000;
+  border-color: #bf4000;
+}
+.wp-theme-6 .btn-two:active,
+.wp-theme-6 .btn-two.active,
+.wp-theme-6 .open .dropdown-toggle.btn-two {
+  background-image: none;
+}
+.wp-theme-6 .btn-three {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid;
+  border-color: #292929;
+}
+.wp-theme-6 .btn-three:hover,
+.wp-theme-6 .btn-three:focus,
+.wp-theme-6 .btn-three:active,
+.wp-theme-6 .btn-three.active,
+.wp-theme-6 .open .dropdown-toggle.btn-three {
+  color: #ffffff;
+  background-color: #1f1f1f;
+  border-color: #1f1f1f;
+}
+.wp-theme-6 .btn-three:active,
+.wp-theme-6 .btn-three.active,
+.wp-theme-6 .open .dropdown-toggle.btn-three {
+  background-image: none;
+}
+.wp-theme-6 .btn-four {
+  background-color: none;
+  border: 2px solid #d35400;
+  color: #d35400;
+}
+.wp-theme-6 .btn-four:hover,
+.wp-theme-6 .btn-four:focus,
+.wp-theme-6 .btn-four:active,
+.wp-theme-6 .btn-four.active,
+.wp-theme-6 .open .dropdown-toggle.btn-four {
+  color: #FFF;
+  background-color: #d35400;
+}
+.wp-theme-6 .btn-four:active,
+.wp-theme-6 .btn-four.active,
+.wp-theme-6 .open .dropdown-toggle.btn-four {
+  background-image: none;
+}
+.wp-theme-6 h1,
+.wp-theme-6 h2,
+.wp-theme-6 h3,
+.wp-theme-6 h4,
+.wp-theme-6 h5,
+.wp-theme-6 h6 {
+  font-family: "Roboto", sans-serif !important;
+}
+.wp-theme-6 p {
+  line-height: 22px;
+}
+.wp-theme-6 a {
+  color: #616161;
+  cursor: pointer;
+}
+.wp-theme-6 a:hover {
+  color: #d35400;
+  text-decoration: none;
+  -o-transition: .3s;
+  -ms-transition: .3s;
+  -moz-transition: .3s;
+  -webkit-transition: .3s;
+  transition: .35s;
+}
+.wp-theme-6 .bg-2 {
+  background: #d35400;
+  color: #FFF;
+}
+.wp-theme-6 .lw .bg-5 {
+  background: #fcfcfc;
+  border-top: 1px solid #e0eded;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-6 .ld .bg-5 {
+  background: #363636;
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-6 .lw .bg-3 {
+  background: #fff;
+  color: #616161;
+}
+.wp-theme-6 .ld .bg-3 {
+  background: #202020;
+  color: #888;
+}
+.wp-theme-6 .bg-4 {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-6 .dark {
+  background: #333;
+  color: #FFF;
+}
+.wp-theme-6 .red {
+  background: #e91b23;
+  color: #FFF;
+}
+.wp-theme-6 .orange {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-6 .green {
+  background: #f39c12;
+  color: #FFF;
+}
+.wp-theme-6 .blue {
+  background: #3498db;
+  color: #FFF;
+}
+.wp-theme-6 .light {
+  background: #fff;
+  color: #616161 !important;
+}
+.wp-theme-6 .blockquote-1:hover {
+  border-color: #d35400;
+}
+.wp-theme-6 .blockquote-1 p {
+  font-size: 13px;
+}
+.wp-theme-6 .section-title {
+  display: inline-block;
+  border-bottom: 1px solid #333;
+  margin: 0 0 15px 0;
+  padding: 0 0 5px 0;
+  font-size: 20px;
+  font-weight: 500;
+  text-transform: capitalize;
+  position: relative;
+  overflow: hidden;
+}
+.wp-theme-6 .lw .section-title {
+  color: #333;
+}
+.wp-theme-6 .ld .section-title {
+  color: #fff;
+}
+.wp-theme-6 .section-title.white {
+  color: #fff;
+  border-bottom: 1px solid #fff;
+}
+.wp-theme-6 .navbar-wp {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  z-index: 1000;
+}
+.wp-theme-6 .lw .navbar-wp {
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-6 .ld .navbar-wp {
+  background: #181818;
+  border-bottom: 1px solid #444;
+}
+.wp-theme-6 .ld .sticky-wrapper .navbar-wp {
+  background: rgba(24, 24, 24, 0.85);
+  border-bottom: 1px solid #444;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > li > a {
+  padding: 28px 16px;
+  margin-right: 0;
+  font-size: 15px;
+  font-weight: normal;
+}
+.wp-theme-6 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-6 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-6 .lw .navbar-wp .navbar-nav > li > a {
+  color: #333;
+}
+.wp-theme-6 .lw .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #333;
+}
+.wp-theme-6 .lw .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-6 .lw .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #d35400;
+}
+.wp-theme-6 .ld .navbar-wp .navbar-nav > li > a {
+  color: #fff;
+}
+.wp-theme-6 .ld .navbar-wp .navbar-nav > li > a.dropdown-form-toggle {
+  color: #fff;
+}
+.wp-theme-6 .ld .navbar-wp .navbar-nav > li > a:hover,
+.wp-theme-6 .ld .navbar-wp .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #d35400;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > .active > a,
+.wp-theme-6 .navbar-wp .navbar-nav > .active > a:hover,
+.wp-theme-6 .navbar-wp .navbar-nav > .active > a:focus {
+  color: #fff !important;
+  background-color: #d35400;
+  border-radius: 0;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > .disabled > a,
+.wp-theme-6 .navbar-wp .navbar-nav > .disabled > a:hover,
+.wp-theme-6 .navbar-wp .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a,
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a:hover,
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a:focus {
+  color: #FFF !important;
+  background-color: #d35400;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a .caret,
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a:hover .caret,
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle,
+.wp-theme-6 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-6 .navbar-wp .navbar-nav > li > a.dropdown-form-toggle:focus {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+  color: #d35400;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle,
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:hover,
+.wp-theme-6 .navbar-wp .navbar-nav > .open > a.dropdown-form-toggle:focus {
+  color: #d35400 !important;
+  background-color: none;
+}
+.wp-theme-6 .navbar-wp .navbar-toggle {
+  border-color: #333;
+  margin-top: 20px;
+}
+.wp-theme-6 .navbar-wp .navbar-toggle .icon-bar {
+  background-color: #4c4c4c;
+}
+.wp-theme-6 .navbar-wp .navbar-toggle .icon-custom {
+  font-size: 18px;
+}
+.wp-theme-6 .navbar-wp .navbar-toggle:hover,
+.wp-theme-6 .navbar-wp .navbar-toggle:focus {
+  background-color: #d35400;
+  border-color: #d35400;
+}
+.wp-theme-6 .navbar-wp .navbar-toggle:hover .icon-bar,
+.wp-theme-6 .navbar-wp .navbar-toggle:focus .icon-bar {
+  background-color: #FFF;
+}
+.wp-theme-6 .navbar-wp .navbar-toggle:hover .icon-custom,
+.wp-theme-6 .navbar-wp .navbar-toggle:focus .icon-custom {
+  color: #FFF;
+}
+.wp-theme-6 .navbar-wp .navbar-toggle-aside-menu {
+  padding: 8px 10px 2px 10px;
+}
+.wp-theme-6 .navbar-wp .navbar-collapse,
+.wp-theme-6 .navbar-wp .navbar-form {
+  border-color: #e7e7e7;
+}
+.wp-theme-6 .navbar-wp .navbar-nav > .dropdown > a:hover .caret,
+.wp-theme-6 .navbar-wp .navbar-nav > .dropdown > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu {
+  min-width: 220px;
+  background: #FFF;
+  border: 0;
+  border-top: 1px solid #d35400;
+  border-bottom: 3px solid #d35400;
+  border-radius: 0;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu > li {
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu > li:last-child {
+  border: 0;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu > li > a {
+  color: #333;
+  padding: 8px 15px;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu > li > a:hover {
+  background: #d35400;
+  color: #FFF;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu label.checkbox {
+  color: #333;
+}
+.wp-theme-6 .navbar-wp .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu-user {
+  border: 1px solid #e0eded;
+  border-top-color: transparent;
+}
+.wp-theme-6 .navbar-wp .dropdown-menu-user {
+  background: #fff;
+}
+.wp-theme-6 .navbar-wp .navbar-right .dropdown-menu-user {
+  background: #fff;
+  border-color: transparent;
+}
+.wp-theme-6 .navbar-wp .navbar-right .social-link {
+  width: 40px;
+  height: 40px;
+  line-height: 20px;
+  text-align: center;
+  padding: 10px;
+  margin: 18px 0;
+  border-radius: 100%;
+}
+.wp-theme-6 .navbar-wp .navbar-right .social-link.facebook:hover {
+  background: #43609c;
+  color: #fff;
+}
+.wp-theme-6 .navbar-wp .navbar-right .social-link.pinterest:hover {
+  background: #cb2027;
+  color: #fff;
+}
+.wp-theme-6 .navbar-wp .navbar-right .social-link.twitter:hover {
+  background: #62addb;
+  color: #fff;
+}
+.wp-theme-6 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-6 .lw .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-6 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:hover,
+.wp-theme-6 .ld .navbar-wp.navbar-contrasted .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: #2c2c2c;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > .open > a,
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover,
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus {
+  color: #FFF;
+  background-color: #2c2c2c;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > .open > a .caret,
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:hover .caret,
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > .open > a:focus .caret {
+  border-top-color: #FFF;
+  border-bottom-color: #FFF;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > .dropdown > a .caret {
+  border-top-color: #4c4c4c;
+  border-bottom-color: #4c4c4c;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle {
+  padding: 15px 16px;
+  margin-top: 14px;
+  font-size: 16px;
+  font-weight: normal;
+  background: none;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:hover,
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-nav > li > a.dropdown-form-toggle:focus {
+  background: none;
+  color: #d35400;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  bottom: 100%;
+  right: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-right: -35px;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  bottom: 100%;
+  left: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .navbar-right .dropdown-menu-user:after {
+  border-color: rgba(136, 183, 213, 0);
+  border-bottom-color: #2c2c2c;
+  border-width: 10px;
+  margin-left: -35px;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu {
+  min-width: 220px;
+  background: #2c2c2c;
+  border: 0;
+  border-top: 0;
+  border-bottom: 0;
+  border-radius: 0;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu > li {
+  border-bottom: 1px solid #262626;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu > li > a {
+  color: #fff;
+  padding: 8px 15px;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu > li > a:hover {
+  background: #d35400;
+  color: #FFF;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-menu label.checkbox {
+  color: #fff;
+}
+.wp-theme-6 .navbar-wp.navbar-contrasted .dropdown-form h4 {
+  margin: 0;
+  padding: 15px 15px 5px 15px;
+  color: #FFF;
+}
+.wp-theme-6 .dropdown-submenu {
+  position: relative;
+}
+.wp-theme-6 .dropdown-submenu > .dropdown-menu {
+  top: -5px;
+  left: 100%;
+  margin-top: 0;
+  margin-left: -1px;
+}
+.wp-theme-6 .dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+.wp-theme-6 .dropdown-submenu > a:after {
+  display: block;
+  content: " ";
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 3px 0 3px 3px;
+  border-left-color: #ccc;
+  margin-top: 5px;
+  margin-right: -6px;
+}
+.wp-theme-6 .dropdown-submenu:hover > a:after {
+  border-left-color: #fff;
+}
+.wp-theme-6 .dropdown-submenu.pull-left {
+  float: none;
+}
+.wp-theme-6 .dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+}
+.wp-theme-6 .nav > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-6 .nav > ul > li {
+  border-bottom: 1px solid #333;
+}
+.wp-theme-6 .nav > ul > li > a {
+  display: block;
+  padding: 10px 15px;
+  font-size: 14px;
+  color: #fff;
+}
+.wp-theme-6 .nav > ul > li > a:hover {
+  text-decoration: none;
+  color: #d35400;
+  background: #292929;
+}
+.wp-theme-6 .nav > ul > li > a > i {
+  margin-right: 5px;
+}
+.wp-theme-6 .lw .pg-opt {
+  border-bottom: 1px solid #e0eded;
+  background: #fcfcfc;
+}
+.wp-theme-6 .ld .pg-opt {
+  border-bottom: 1px solid #444;
+  background: #111;
+}
+.wp-theme-6 .pg-opt.fixed {
+  width: 100%;
+  position: fixed;
+  top: 0px;
+  background: rgba(250, 250, 250, 0.9);
+  border-bottom: 1px solid #e0eded;
+  z-index: 900;
+}
+.wp-theme-6 .pg-opt h2 {
+  margin: 0;
+  padding: 14px 0;
+  font-size: 22px;
+  line-height: 100%;
+}
+.wp-theme-6 .pg-opt.fixed h2 {
+  margin-bottom: 15px;
+}
+.wp-theme-6 .pg-opt hr {
+  margin: 0;
+  border-top-color: #dde1e6;
+  -webkit-box-shadow: 0 1px 0 #fbfbfc;
+  -moz-box-shadow: 0 1px 0 #fbfbfc;
+  box-shadow: 0 1px 0 #fbfbfc;
+}
+.wp-theme-6 .pg-opt.fixed hr {
+  display: none;
+}
+.wp-theme-6 .pg-opt .breadcrumb {
+  float: right;
+  margin: 0;
+  padding: 16px 0;
+  background: none;
+  border-radius: 0;
+}
+.wp-theme-6 .pg-opt .breadcrumb a {
+  color: #d35400;
+}
+@media only screen and (max-width: 767px) {
+  .wp-theme-6 .pg-opt .pg-nav {
+    float: left;
+    margin-bottom: 10px;
+  }
+  .wp-theme-6 .pg-opt h2 {
+    padding: 20px 0 0 0;
+  }
+}
+.wp-theme-6 .page-header {
+  margin: 0;
+  border: 0;
+}
+.wp-theme-6 .page-header p {
+  font-size: 16px;
+}
+.wp-theme-6 .w-box {
+  margin: 0 0 15px 0;
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+  border: 1px solid #e0eded;
+}
+.wp-theme-6 .w-box:before,
+.wp-theme-6 .w-box:after {
+  display: table;
+  content: "";
+}
+.wp-theme-6 .w-box:after {
+  clear: both;
+}
+.wp-theme-6 .w-box h1 {
+  margin: 0;
+  padding: 10px 15px;
+  font-weight: 500;
+  font-size: 20px;
+}
+.wp-theme-6 .lw .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #333;
+}
+.wp-theme-6 .ld .w-box h2 {
+  margin: 0;
+  padding: 12px 15px 0px 15px;
+  font-weight: 500;
+  font-size: 16px;
+  color: #fff;
+}
+.wp-theme-6 .w-box.inner h2 {
+  padding: 10px 0;
+}
+.wp-theme-6 .w-box small {
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+.wp-theme-6 .w-box p {
+  margin: 6px 0;
+  padding: 0 15px;
+  padding-bottom: 8px;
+}
+.wp-theme-6 .w-box time {
+  display: block;
+  padding: 8px 15px 0 15px;
+}
+.wp-theme-6 .w-box .w-footer {
+  padding: 10px 15px;
+  border-top: 1px solid #f1f1f1;
+}
+.wp-theme-6 .w-box .w-footer:before,
+.wp-theme-6 .w-box .w-footer:after {
+  display: table;
+  content: "";
+}
+.wp-theme-6 .w-box .w-footer:after {
+  clear: both;
+}
+.wp-theme-6 .w-box .w-footer small {
+  font-size: 12px;
+}
+.wp-theme-6 .w-box .w-box-parent {
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+}
+.wp-theme-6 .w-box .date-over {
+  padding: 10px;
+  background: #ffffff;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  text-align: center;
+  font-weight: normal;
+}
+.wp-theme-6 .w-box .date-over.small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.wp-theme-6 .w-box .date-over strong {
+  font-size: 12px;
+  display: block;
+  font-weight: normal;
+}
+.wp-theme-6 .w-box.dark {
+  background: #333;
+}
+.wp-theme-6 .w-box.dark h2 {
+  color: #fff;
+}
+.wp-theme-6 .w-box.white h2 {
+  border-bottom: 0;
+  text-align: center;
+}
+.wp-theme-6 .w-box.white .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.wp-theme-6 .lw .w-box.white {
+  background: #FFF;
+}
+.wp-theme-6 .lw .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-6 .ld .w-box.white {
+  background: #202020;
+  border: 1px solid #444;
+}
+.wp-theme-6 .ld .w-box.white .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.wp-theme-6 .w-box.w-box-inverse .thmb-img i {
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  font-size: 34px;
+  line-height: 100px;
+  text-align: center;
+}
+.wp-theme-6 .lw .w-box.w-box-inverse .thmb-img i {
+  background: #fcfcfc;
+  color: #d35400;
+}
+.wp-theme-6 .ld .w-box.w-box-inverse .thmb-img i {
+  background: #363636;
+  color: #fff;
+}
+.wp-theme-6 .w-box.w-box-inverse .thmb-img:hover i {
+  background: #d35400;
+  color: #FFF;
+}
+.wp-theme-6 .c-box {
+  border: 1px solid #d35400;
+}
+.wp-theme-6 .c-box .c-box-header {
+  padding: 10px 15px;
+  background: #d35400;
+  color: #fff;
+  font-size: 16px;
+  text-transform: capitalize;
+}
+.wp-theme-6 .c-box .table {
+  margin: 0;
+}
+.wp-theme-6 .ld .w-section h4,
+.wp-theme-6 .ld .w-section h3,
+.wp-theme-6 .ld .w-section h2 {
+  color: #fff;
+}
+.wp-theme-6 .w-section .aside-feature {
+  margin: 10px;
+  cursor: default;
+}
+.wp-theme-6 .w-section .aside-feature .icon-feature {
+  font-size: 68px;
+  margin-top: 10px;
+  text-align: center;
+  display: block;
+}
+.wp-theme-6 .w-section .aside-feature:hover .icon-feature,
+.wp-theme-6 .w-section .aside-feature:hover h4 {
+  color: #d35400;
+}
+.wp-theme-6 .w-section .aside-feature .img-feature {
+  margin-top: 4px;
+  display: block;
+}
+.wp-theme-6 .w-section .aside-feature .img-feature img {
+  width: 78px;
+}
+.wp-theme-6 .layer-slider-wrapper {
+  max-height: 500px;
+  overflow: hidden;
+  border-bottom: 1px solid #e0eded;
+}
+.wp-theme-6 .layer-slider-wrapper .title {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-6 .layer-slider-wrapper .title.title-base {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #FFF;
+  background: #e91b23;
+  text-transform: capitalize;
+}
+.wp-theme-6 .layer-slider-wrapper .title.title-dark {
+  font-size: 36px;
+  line-height: 46px;
+  font-weight: 500;
+  color: #333;
+  text-transform: capitalize;
+}
+.wp-theme-6 .layer-slider-wrapper .subtitle {
+  font-size: 22px;
+  line-height: 30px;
+  color: #d35400;
+  text-transform: capitalize;
+}
+.wp-theme-6 .layer-slider-wrapper .list-item {
+  font-size: 18px;
+  line-height: 30px;
+  padding-left: 30px;
+  color: #d35400;
+  text-transform: capitalize;
+}
+.wp-theme-6 .layer-slider-wrapper .text-standard {
+  font-size: 16px;
+  line-height: 22px;
+}
+.wp-theme-6 .box-element {
+  padding: 20px;
+}
+.wp-theme-6 .box-element:nth-child(n+1) {
+  margin-top: 20px;
+}
+.wp-theme-6 .box-element h1 {
+  margin: 10px 0 !important;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 400;
+}
+.wp-theme-6 .box-element.box-element-bordered {
+  background: transparent !important;
+  border: 1px solid #d35400;
+}
+.wp-theme-6 .box-element.box-element-outer {
+  padding-left: 0;
+  padding-right: 0;
+}
+.wp-theme-6 .pricing-plans .plan-header .popular-tag {
+  background: #333;
+  border-bottom: 1px solid #FFF;
+  color: #fff;
+}
+.wp-theme-6 .carousel-2 {
+  position: relative;
+}
+.wp-theme-6 .carousel-2 .item {
+  padding: 36px 0 !important;
+}
+.wp-theme-6 .carousel-2 .carousel-indicators {
+  bottom: 0;
+}
+.wp-theme-6 .carousel-2 .carousel-indicators li {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+}
+.wp-theme-6 .carousel-2 .carousel-indicators .active {
+  background-color: #d35400;
+}
+.wp-theme-6 .carousel-2 .img-thumbnail {
+  margin-top: 26px;
+}
+.wp-theme-6 .carousel-2 h2 {
+  font-size: 22px;
+}
+.wp-theme-6 .carousel-2 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: 10px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #d35400;
+  opacity: 1;
+}
+.wp-theme-6 .carousel-2 .carousel-nav a:hover {
+  background: #d35400 !important;
+  color: #fff;
+}
+.wp-theme-6 .carousel-2 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-6 .carousel-2 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-6 .carousel-2 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  font-size: 22px;
+  margin-top: -11px;
+}
+.wp-theme-6 .carousel-2 .carousel-control.left i {
+  left: 18px;
+}
+.wp-theme-6 .carousel-2 .carousel-control.right i {
+  right: 18px;
+}
+.wp-theme-6 .carousel-3 {
+  position: relative;
+}
+.wp-theme-6 .carousel-3 .carousel-nav a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  top: -50px;
+  right: 0;
+  margin-top: 0;
+  font-size: 18px;
+  text-align: center;
+  border: 1px solid transparent;
+  background: #f5f5f5;
+  color: #d35400;
+  opacity: 1;
+}
+.wp-theme-6 .carousel-3 .carousel-nav a:hover {
+  background: #d35400 !important;
+  color: #fff;
+}
+.wp-theme-6 .carousel-3 .carousel-nav a.left {
+  right: 36px;
+}
+.wp-theme-6 .carousel-3 .carousel-nav a.right {
+  right: 0;
+}
+.wp-theme-6 .carousel-3 .carousel-nav a:hover {
+  background: #FFF;
+}
+.wp-theme-6 .carousel-testimonials {
+  position: relative;
+  border: 1px solid #e0eded;
+}
+.wp-theme-6 .like-button .button {
+  display: block;
+  text-align: right;
+  padding-top: 10px;
+  color: #ddd;
+}
+.wp-theme-6 .like-button .button i {
+  font-size: 20px;
+  color: #ddd;
+}
+.wp-theme-6 .like-button .button.liked i {
+  color: #d35400;
+}
+.wp-theme-6 .like-button .count {
+  display: block;
+  text-align: right;
+  position: relative;
+  top: -7px;
+}
+.wp-theme-6 .like-button.inline .button {
+  display: inline-block;
+  padding: 0;
+}
+.wp-theme-6 .like-button.inline .count {
+  display: inline-block;
+  top: -2px;
+}
+.wp-theme-6 .like-button.inline .count small {
+  font-size: 13px;
+}
+.wp-theme-6 .side-like-box {
+  text-align: center;
+  padding: 5px 5px 0 5px;
+  margin-top: 10px;
+}
+.wp-theme-6 .side-like-box .button {
+  text-align: center;
+  padding: 0;
+}
+.wp-theme-6 .side-like-box .count {
+  text-align: center;
+}
+.wp-theme-6 .side-like-box i {
+  font-size: 24px;
+}
+.wp-theme-6 ul.list-listings {
+  margin: 0 0 20px 0;
+  padding: 0;
+  list-style: none;
+}
+.wp-theme-6 ul.list-listings li {
+  margin-bottom: 30px;
+  border: 1px solid #f3f3f3;
+  overflow: hidden;
+}
+.wp-theme-6 ul.list-listings li.featured {
+  border-color: #d35400;
+}
+.wp-theme-6 ul.list-listings li:before,
+.wp-theme-6 ul.list-listings li:after {
+  content: "";
+  display: table;
+}
+.wp-theme-6 ul.list-listings li:after {
+  clear: both;
+}
+.wp-theme-6 ul.list-listings .listing-header {
+  clear: both;
+  padding: 8px 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.wp-theme-6 ul.list-listings .listing-image {
+  width: 25%;
+  height: 150px;
+  float: left;
+  overflow: hidden;
+}
+.wp-theme-6 ul.list-listings .listing-body {
+  width: 50%;
+  height: 150px;
+  padding: 15px;
+  float: left;
+  background: #fcfcfc;
+  border-right: 1px solid #fcfcfc;
+}
+.wp-theme-6 ul.list-listings .listing-body h3 {
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 25px;
+}
+.wp-theme-6 ul.list-listings .listing-body h4 {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 22px;
+}
+.wp-theme-6 ul.list-listings .listing-actions {
+  width: 25%;
+  height: 110px;
+  padding-top: 40px;
+  float: left;
+  text-align: center;
+}
+.wp-theme-6 ul.list-listings .listing-actions .btn {
+  margin-top: 6px;
+}
+.wp-theme-6 ul.list-check {
+  list-style: none;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+}
+.wp-theme-6 ul.list-check li {
+  padding: 4px 0;
+  margin: 0;
+  display: block;
+  width: 100%;
+}
+.wp-theme-6 ul.list-check li i {
+  color: #d35400;
+  font-style: normal;
+  margin-right: 4px;
+}
+.wp-theme-6 ul.list-check li span {
+  font-size: 14px;
+}
+.wp-theme-6 ul.categories {
+  list-style: none;
+  margin: 0;
+  padding: 0 !important;
+  border: 1px solid #e0eded;
+  overflow: hidden;
+}
+.wp-theme-6 ul.categories li {
+  border-bottom: 1px solid #e0eded;
+  position: reltive;
+}
+.wp-theme-6 ul.categories li:last-child {
+  border: 0;
+}
+.wp-theme-6 ul.categories li a {
+  display: block;
+  padding: 10px 15px;
+}
+.wp-theme-6 ul.categories li a:after {
+  font-family: 'FontAwesome';
+  content: "\f105";
+  position: relative;
+  top: 0;
+  float: right;
+}
+.wp-theme-6 ul.categories li a:hover {
+  background: #d35400;
+  color: #FFF;
+  text-decoration: none;
+}
+.wp-theme-6 ul.categories li a i {
+  display: inline-block;
+  vertical-align: middle;
+  padding-right: 5px;
+  font-style: normal;
+  color: #999;
+  font-size: 11px;
+}
+.wp-theme-6 ul.categories li a:hover i {
+  color: #FFF;
+}
+.wp-theme-6 .timeline .year {
+  width: 100%;
+  background: #333;
+  padding: 8px 10px;
+  margin: 20px auto 40px !important;
+  font-size: 20px;
+}
+.wp-theme-6 .timeline .year {
+  border-radius: 3px;
+}
+.wp-theme-6 .timeline .event {
+  padding: 0;
+  border: 1px solid #e0eded;
+  border-radius: 0;
+}
+.wp-theme-6 .timeline .event:nth-child(2n):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -6.8% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #d35400;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-6 .timeline .event:nth-child(2n-1):after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #FFF;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+}
+.wp-theme-6 .timeline .event:nth-child(2n-1):before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -6.5% !important;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  background: #d35400;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+.wp-theme-6 .timeline .event-date {
+  margin: 0;
+  background: #FFF;
+  border-bottom: 1px solid #e0eded;
+  text-align: left;
+  padding: 10px 10px;
+  font-weight: 500;
+  font-size: 14px;
+}
+.wp-theme-6 .timeline .event:nth-child(2n) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-6 .timeline .event:nth-child(2n) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  right: -13px;
+  width: 0;
+  height: 0;
+  border-left: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-6 .timeline .event:nth-child(2n-1) .event-date:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: -12px !important;
+  top: 12px;
+  width: 0;
+  height: 0;
+  border-right: 12px solid #fff;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  z-index: 20;
+}
+.wp-theme-6 .timeline .event:nth-child(2n-1) .event-date:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 11px;
+  left: -13px;
+  width: 0;
+  height: 0;
+  border-right: 13px solid #ddd;
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent;
+  z-index: 0;
+}
+.wp-theme-6 .timeline .event-date small {
+  display: block;
+  font-size: 12px;
+  color: #a1a1a1;
+  font-weight: normal;
+}
+.wp-theme-6 .timeline .event-date i {
+  margin-right: 7px;
+}
+.wp-theme-6 .timeline .event-body {
+  background: #f8f8f8;
+}
+.wp-theme-6 .timeline .event-footer {
+  margin: 0;
+  text-align: left;
+  padding: 8px 10px;
+  background: none;
+  border-top: 1px solid #e0eded;
+}
+.wp-theme-6 .timeline .event-footer:after,
+.wp-theme-6 .timeline .event-footer:before {
+  display: table;
+  content: " ";
+}
+.wp-theme-6 .timeline .event-footer:after {
+  clear: both;
+}
+.wp-theme-6 .timeline .event img {
+  margin: 0;
+}
+.wp-theme-6 .timeline p {
+  padding: 20px 10px;
+  text-align: left;
+}
+.wp-theme-6 .timeline iframe {
+  margin: 10px 0 0 0;
+}
+.wp-theme-6 #toTop {
+  display: none;
+  text-decoration: none;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+  border: none;
+  text-indent: 100%;
+  background: #555;
+  border-radius: 3px;
+}
+.wp-theme-6 #toTopHover {
+  background: #d35400;
+  width: 40px;
+  height: 40px;
+  display: block;
+  overflow: hidden;
+  float: left;
+  opacity: 0;
+  -moz-opacity: 0;
+  filter: alpha(opacity=0);
+}
+.wp-theme-6 #toTop:active,
+.wp-theme-6 #toTop:focus {
+  outline: none;
+}
+.wp-theme-6 #toTop:before {
+  font-family: 'FontAwesome';
+  content: "\f106";
+  color: #ffffff;
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  line-height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  text-indent: 0;
+}
+.wp-theme-6 .widget.tags-wr {
+  padding-bottom: 15px;
+}
+.wp-theme-6 .tags-list:before,
+.wp-theme-6 .tags-list:after {
+  display: table;
+  content: "";
+}
+.wp-theme-6 .tags-list:after {
+  clear: both;
+}
+.wp-theme-6 .tags-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.wp-theme-6 .tags-list li {
+  border: 1px solid #d35400;
+  background: #FFF;
+  padding: 5px;
+  float: left;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  color: #d35400;
+  font-size: 12px;
+}
+.wp-theme-6 .tags-list li a {
+  color: #d35400;
+  margin-left: 4px;
+}
+.wp-theme-6 .tags-list li:hover {
+  background: #d35400;
+  color: #FFF;
+}
+.wp-theme-6 .tags-list li:hover a {
+  color: #FFF;
+  text-decoration: none;
+}
+.progress {
+  height: 28px;
+  margin-bottom: 15px;
+  overflow: hidden;
+  background-color: #f5f5f5;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.progress .sr-only {
+  width: auto;
+  height: 28px;
+  margin: 0;
+  margin-left: 30px;
+  left: 0;
+  clip: auto;
+  line-height: 28px;
+  font-size: 14px;
+}
+.progress-bar-one {
+  background-color: #e06d58;
+}
+.progress-bar-two {
+  background-color: #697e93;
+}
+.progress-bar-three {
+  background-color: #3b3e43;
+}
+.progress-bar-four {
+  background-color: #FFF;
+}
+div.tabs {
+  margin-bottom: 0;
+}
+div.tabs:before,
+div.tabs:after {
+  display: table;
+  content: " ";
+}
+div.tabs:after {
+  clear: both;
+}
+div.tabs div.tab-content {
+  -moz-border-radius: none;
+  -moz-box-shadow: none;
+  -webkit-border-radius: 0;
+  -webkit-box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #EEE;
+  border-radius: 0;
+  border-top: 0;
+  box-shadow: none;
+  padding: 15px;
+}
+div.tabs div.tab-content.tab-content-inverse {
+  border: 1px solid #EEE;
+  background: transparent;
+}
+div.tabs ul.nav-tabs {
+  margin: 0;
+}
+div.tabs ul.nav-tabs li.active a {
+  background: #fff;
+  border-top: 1px solid #ddd;
+  color: #CCC;
+}
+div.tabs ul.nav-tabs a {
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  background: #f7f7f7;
+  border: 0;
+  border-bottom: 0;
+  margin-right: 0;
+  color: #333;
+}
+div.tabs ul.nav-tabs a:hover {
+  border-top: 1px solid #ddd;
+  color: #7a92ac;
+}
+div.tabs ul.nav-tabs a:active,
+div.tabs ul.nav-tabs a:focus {
+  border-bottom: 0;
+}
+div.tabs-left ul.nav-tabs a:active,
+div.tabs-left ul.nav-tabs a:focus {
+  border-right: 0;
+}
+div.tabs ul.nav-tabs a,
+div.tabs ul.nav-tabs a:hover {
+  border: 1px solid #EEE;
+  border-right: 0;
+  border-top: 1px solid #ddd;
+  font-size: 0.9em;
+}
+div.tabs ul.nav-tabs a:last-child,
+div.tabs ul.nav-tabs a:last-child:hover {
+  border-right: 1px solid #ddd;
+}
+div.tabs-left ul.nav-tabs a,
+div.tabs-left ul.nav-tabs a:hover {
+  border: 1px solid #EEE;
+  border-right: 0;
+  border-left: 2px solid #DDD;
+  color: #CCC;
+  font-size: 0.9em;
+}
+div.tabs-right ul.nav-tabs a,
+div.tabs-right ul.nav-tabs a:hover {
+  border: 1px solid #EEE;
+  border-left: 0;
+  border-right: 2px solid #DDD;
+  color: #CCC;
+  font-size: 0.9em;
+}
+/* tab left */
+.tabbable.tabs-left {
+  -moz-border-radius: 2px;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+  margin-bottom: 30px;
+}
+div.tabbable.tabs-left div.tab-content {
+  -moz-border-radius: 0 0 2px 2px;
+  -moz-box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.04);
+  -webkit-border-radius: 0 0 2px 2px;
+  -webkit-box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.04);
+  background-color: #FFF;
+  border: 1px solid #EEE;
+  border-radius: 0 0 2px 2px;
+  border-left: 0;
+  box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.04);
+  padding: 15px;
+}
+div.tabbable.tabs-left ul.nav-tabs a {
+  -moz-border-radius: 2px 2px 0 0;
+  -webkit-border-radius: 2px 2px 0 0;
+  background: #f7f7f7;
+  border: 1px solid #EEE;
+  border-right: 0;
+  border-radius: 2px 2px 0 0;
+  color: #666;
+  margin-bottom: 3px;
+}
+div.tabbable.tabs-left ul.nav-tabs li.active a {
+  background: #fff;
+  color: #CCC;
+}
+/* tab right */
+.tabbable.tabs-right {
+  -moz-border-radius: 2px;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+  margin-bottom: 30px;
+}
+div.tabbable.tabs-right div.tab-content {
+  -moz-border-radius: 0 0 2px 2px;
+  -moz-box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.04);
+  -webkit-border-radius: 0 0 2px 2px;
+  -webkit-box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.04);
+  background-color: #FFF;
+  border: 1px solid #EEE;
+  border-radius: 0 0 2px 2px;
+  border-left: 0;
+  margin: 0;
+  box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.04);
+  padding: 15px;
+}
+div.tabbable.tabs-right ul.nav-tabs a {
+  -moz-border-radius: 2px 2px 0 0;
+  -webkit-border-radius: 2px 2px 0 0;
+  background: #f7f7f7;
+  border: 1px solid #EEE;
+  border-left: 0;
+  border-radius: 2px 2px 0 0;
+  color: #666;
+  margin-bottom: 3px;
+}
+div.tabbable.tabs-right ul.nav-tabs li.active a {
+  background: #fff;
+  color: #CCC;
+}
+.tabs-centered {
+  width: 100%;
+  display: table;
+  margin: 0 auto;
+}
+.tabs-centered ul li {
+  width: 100px;
+  display: inline-block;
+  float: none;
+}
+.nav-pills {
+  margin-bottom: 15px;
+  border: 1px solid #EEE;
+}
+.nav-pills > li > a {
+  border-radius: 0;
+  border-right: 1px solid #e0eded;
+}
+.nav-pills > li:last-child > a {
+  border-radius: 0;
+  border-right: 0;
+}
+.nav-pills > li > a:hover,
+.nav-pills > li > a:focus {
+  background: #f5f5f5;
+}
+.nav-pills > li + li {
+  margin-left: 2px;
+}
+.nav-pills > li.active > a,
+.nav-pills > li.active > a:hover,
+.nav-pills > li.active > a:focus {
+  color: #e91b23;
+  background: none;
+}
+.panel {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.panel-group {
+  margin-bottom: 30px;
+}
+.panel-group .panel {
+  border-radius: 0;
+}
+.panel-group .panel + .panel {
+  margin-top: 0;
+  border-top: 0;
+}
+.panel-group .panel-heading {
+  padding: 14px 15px;
+  position: relative;
+}
+.panel-group .panel-heading:after {
+  content: "+";
+  font-size: 12px;
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  margin-top: -8px;
+}
+.panel-group .panel-heading:after {
+  content: "+";
+  font-size: 12px;
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  margin-top: -8px;
+}
+.panel-group .panel-heading a {
+  font-weight: normal;
+}
+.panel-group .panel-heading a i {
+  margin-right: 5px;
+  color: #e91b23;
+}
+.panel {
+  border-radius: 0;
+}
+.panel .panel-heading {
+  border-radius: 0;
+}
+.modal-footer {
+  margin-top: 0;
+}
+.alert {
+  border-radius: 0;
+}
+.table > thead > tr > th {
+  border-bottom: 1px solid #ddd;
+}
+.table > thead > tr {
+  background: #f3f3f3;
+}
+/* GLOBAL */
+iframe {
+  border: 0;
+  margin-top: 0 !important;
+}
+h1.font-lg {
+  font-size: 100px;
+  font-weight: 600;
+}
+/* MARGINS & PADDINGS & OTHER */
+.no-padding {
+  padding: 0 !important;
+}
+.no-margin {
+  margin: 0 !important;
+}
+.p-15 {
+  padding: 15px !important;
+}
+.p-50 {
+  padding: 50px 0 !important;
+}
+.pb-10 {
+  padding-bottom: 10px;
+}
+.pb-20 {
+  padding-bottom: 20px;
+}
+.pt-10 {
+  padding-top: 10px;
+}
+.pt-20 {
+  padding-top: 20px;
+}
+.pl-20 {
+  padding-left: 20px;
+}
+.mt-20 {
+  margin-top: 20px;
+}
+.mb-20 {
+  margin-bottom: 20px;
+}
+.padding-y-10 {
+  padding: 10px 0;
+}
+.padding-x-4 {
+  padding: 0 4px;
+}
+.padding-x-8 {
+  padding: 0 8px;
+}
+.padding-x-16 {
+  padding: 0 16px;
+}
+.padding-x-20 {
+  padding: 0 20px;
+}
+.padding-x-32 {
+  padding: 0 32x;
+}
+.padding-y-20 {
+  padding: 20px 0 !important;
+}
+.margin-b-10 {
+  margin-bottom: 10px;
+}
+.margin-b-20 {
+  margin-bottom: 20px;
+}
+.margin-t-15 {
+  margin-top: 15px;
+}
+.margin-t-20 {
+  margin-top: 20px;
+}
+.margin-y-10 {
+  margin: 10px 0;
+}
+.margin-y-20 {
+  margin: 20px 0;
+}
+.margin-x-20 {
+  margin: 0 20px;
+}
+.strong {
+  font-weight: bold !important;
+}
+.img-center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+/* BANNERS */
+.bg-banner-1 {
+  padding: 54px 0 !important;
+  background: url(../images/prv/banner-img-4.jpg) fixed no-repeat !important;
+  color: #fff;
+}
+.bg-banner-2 {
+  padding: 54px 0 !important;
+  background: url(../images/prv/banner-img-1.jpg) no-repeat fixed !important;
+  color: #fff;
+}
+/* MASKS */
+.mask-dark {
+  display: none;
+  position: relative;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: url(../images/background/slash_it.png);
+  opacity: 0.4;
+}
+/* IMAGES */
+.img-thumbnail {
+  border-radius: 0;
+}
+/* BLOCKQUOTES*/
+.blockquote-1 {
+  margin-top: 20px;
+}
+/* HEADER */
+header {
+  padding: 0;
+}
+header .navbar-brand {
+  padding: 0 15px;
+  margin-top: 14px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+}
+header .navbar-brand img {
+  height: 46px;
+}
+header .navbar-fixed {
+  width: 100%;
+  left: 0;
+}
+header .navbar-fixed .navbar {
+  width: 100%;
+}
+/* TOP HEADER */
+.top-header {
+  border-bottom: 1px solid #eee;
+  background: #fff;
+}
+.top-header .aux-text {
+  padding: 10px 0;
+  color: #999;
+  font-size: 11px;
+}
+.top-header .top-header-menu {
+  float: right;
+}
+.top-header .top-header-menu > ul.menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.top-header .top-header-menu > ul.menu > li {
+  position: relative;
+  float: left;
+  display: inline-block;
+  border-right: 1px solid #eee;
+}
+.top-header .top-header-menu > ul.menu > li:last-child {
+  border: 0;
+}
+.top-header .top-header-menu > ul.menu > li > a {
+  display: block;
+  padding: 10px 15px;
+  color: #333;
+}
+.top-header .top-header-menu > ul.menu > li.dropdown > a:after {
+  content: "\f107";
+  margin-left: 6px;
+  font-family: "FontAwesome";
+  position: relative;
+  float: right;
+}
+.top-header .top-header-menu ul.menu > li > a > i {
+  margin-right: 6px;
+}
+.top-header .top-header-menu ul.menu > li ul.sub-menu {
+  display: none;
+  min-width: 160px;
+  position: absolute;
+  right: -1px;
+  z-index: 1500;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #eee;
+  opacity: 0;
+  -moz-opacity: 0;
+  filter: alpha(opacity=0);
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  -moz-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  -webkit-transition: all 0.2s ease-in-out;
+  -moz-transition: all 0.2s ease-in-out;
+  -o-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+}
+.top-header .top-header-menu ul.menu > li:hover ul.sub-menu {
+  opacity: 1;
+  display: block;
+}
+.top-header .top-header-menu ul.menu > li ul.sub-menu > li {
+  border-bottom: 1px solid #eee;
+}
+.top-header .top-header-menu ul.menu > li ul.sub-menu > li:last-child {
+  border: 0;
+}
+.top-header .top-header-menu ul.menu > li ul.sub-menu > li > a {
+  display: block;
+  padding: 6px 15px;
+  color: #33;
+}
+.top-header .top-header-menu ul.menu > li ul.sub-menu > li > .language-active {
+  display: block;
+  padding: 6px 15px;
+  background: #f8f8f8;
+  cursor: default;
+}
+.top-header .top-header-menu ul.menu > li.dropdown:hover .sub-menu {
+  display: block;
+}
+.top-header.top-header-dark {
+  border-bottom: 1px solid #222;
+  background: #020202;
+}
+.top-header.top-header-dark .aux-text {
+  color: #fff;
+}
+.top-header.top-header-dark .top-header-menu > ul.menu > li {
+  border-color: #222;
+}
+.top-header.top-header-dark .top-header-menu > ul.menu > li > a {
+  color: #fff;
+}
+/* STICKY WRAPPER */
+/* NAVBAR FORM */
+.dropdown-form {
+  min-width: 300px;
+  z-index: 500;
+}
+.dropdown-cart {
+  min-width: 400px;
+  padding: 15px;
+}
+.dropdown-cart .cart-items {
+  display: block;
+  margin-bottom: 15px;
+  font-size: 14px;
+  font-wight: 500;
+}
+.dropdown-menu h4 {
+  font-size: 14px;
+  color: #4c4c4c;
+}
+.dropdown-profile {
+  padding: 15px;
+}
+.dropdown-profile img {
+  width: 60px;
+}
+/* WRAPPER */
+.aside-menu-in .wrapper {
+  left: -280px;
+}
+.wrapper {
+  position: relative;
+  left: 0;
+  -webkit-transition: all 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  -moz-transition: all 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  -o-transition: all 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: all 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  /* easeOutQuad */
+  -webkit-transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  -moz-transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  -o-transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  /* easeOutQuad */
+}
+/* ASIDE MENU */
+.aside-menu {
+  width: 280px;
+  height: 100%;
+  overflow-y: scroll;
+  position: fixed;
+  right: 0;
+  top: 0;
+  background: #222222;
+  border-left: 1px solid #333;
+  display: none;
+}
+.aside-menu::-webkit-scrollbar {
+  display: none !importat;
+  width: 0 !important;
+}
+.aside-menu .form-search {
+  margin: 0;
+  padding: 0;
+  border-bottom: 1px solid #333;
+}
+.aside-menu .form-search .form-input {
+  padding: 0;
+}
+.aside-menu .form-search .form-control {
+  display: block;
+  height: 34px;
+  padding: 21px 15px;
+  color: #fff;
+  background-color: transparent;
+  border: 0;
+  border-radius: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  -webkit-transition: none;
+}
+.aside-menu .form-search .btn-close {
+  background: transparent;
+  color: #fff;
+}
+.aside-menu .form-search .btn-close i {
+  font-weight: 300 !important;
+  font-size: 16px;
+}
+.aside-menu .social-media {
+  padding: 15px;
+  padding-bottom: 0;
+}
+.aside-menu .contact-info {
+  padding: 15px;
+  color: #fff;
+}
+.aside-menu .contact-info h5 {
+  font-size: 12px;
+}
+.side-section-title {
+  position: relative;
+  overflow: hidden;
+  margin: 0;
+  margin-top: 15px;
+  padding: 8px 15px;
+  font-size: 11px;
+  text-transform: uppercase;
+  color: #616161;
+}
+.side-section-title:after {
+  content: "";
+  height: 1px;
+  background: #333;
+  width: 80px;
+  position: absolute;
+  top: 26px;
+  left: 15px;
+}
+/* STYLE SWITCHER */
+.style-switcher-slidebar {
+  width: 310px;
+  height: 420px;
+  position: fixed;
+  left: -260px;
+  top: 130px;
+  z-index: 10999;
+  -webkit-transition: all 0.5s ease;
+  -moz-transition: all 0.5s ease;
+  -o-transition: all 0.5s ease;
+  -ms-transition: all 1s ease;
+  transition: all 0.5s ease;
+}
+.style-switcher-slidebar.opened {
+  left: 0;
+}
+.style-switcher-slidebar .switch-panel {
+  float: left;
+  width: 255px;
+  height: 370px;
+  background: #fff;
+  color: #333333;
+  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3);
+}
+a.open-panel {
+  text-align: center;
+  line-height: 50px;
+  font-size: 30px;
+  color: #fff !important;
+  background-color: #e91b23;
+  display: block;
+  height: 50px;
+  width: 50px;
+  float: right;
+  margin: 0;
+  z-index: 1000;
+  position: relative;
+  -webkit-transition: none;
+  -moz-transition: none;
+  -o-transition: none;
+}
+a.open-panel:hover {
+  color: #fff;
+}
+.style-switcher-slidebar label {
+  margin-bottom: 0;
+}
+.style-switcher-slidebar h3 {
+  height: 50px;
+  line-height: 50px;
+  margin: 0 0 10px 0;
+  padding: 0 10px;
+  background: #e91b23;
+  font-size: 16px;
+  color: #fff;
+}
+.style-switcher-slidebar .panel-section {
+  padding: 0 15px;
+}
+.color-picker {
+  display: block;
+}
+.color-picker a {
+  width: 30px;
+  height: 30px;
+  display: inline-block;
+  margin-right: 5px;
+  margin-bottom: 8px;
+  text-indent: -9999px;
+}
+.color-picker a:last-child {
+  margin-right: 0;
+}
+.color-picker a.color-red {
+  background: #e91b23;
+}
+.color-picker a.color-violet {
+  background: #563d7c;
+}
+.color-picker a.color-blue {
+  background: #59b2e5;
+}
+.color-picker a.color-green {
+  background: #8ec449;
+}
+.color-picker a.color-yellow {
+  background: #f1c40f;
+}
+.color-picker a.color-orange {
+  background: #d35400;
+}
+/* SEARCH */
+.search-wr {
+  width: 100%;
+  height: 110px;
+  background: #FFF;
+  position: fixed;
+  top: 0;
+  z-index: 2200;
+  display: none;
+  -webkit-box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
+  -moz-box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
+}
+.search-wr .close {
+  display: block;
+  width: 22px;
+  height: 22px;
+  position: relative;
+  float: right;
+  top: 10px;
+  right: 10px;
+}
+.search-wr .close i {
+  font-size: 20px;
+  color: #555;
+}
+.search-wr .search-sign i {
+  font-size: 60px;
+  line-height: 110px;
+  color: #DDD;
+}
+.global-search-input {
+  padding: 40px 0 0 0;
+  font-size: 20px;
+  position: relative;
+  width: 740px;
+  background: #fff;
+  z-index: 10;
+  border: none;
+  outline: none;
+  color: #DDD;
+}
+.global-search-input:focus {
+  color: #333;
+}
+/* CAROUSELS */
+.carousel-1 {
+  overflow: hidden;
+}
+.carousel-1 .carousel-inner {
+  height: 440px;
+}
+.carousel-1 .carousel-control {
+  color: #f8f8f8;
+}
+.carousel-1 .carousel-control.left {
+  left: -40px;
+}
+.carousel-1 .carousel-control.right {
+  right: -40px;
+}
+.carousel-1 .carousel-control:hover {
+  color: #fff;
+}
+.carousel-1 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  margin-top: -18px;
+  font-size: 36px;
+  font-weight: 600;
+}
+.carousel-1 .item {
+  height: 440px;
+}
+.carousel-1 .item {
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: 0% 0%;
+}
+.carousel-1 .item-dark {
+  color: #FFF;
+}
+.carousel-1 .item-light {
+  color: #FFF;
+}
+.carousel-1 p {
+  font-size: 16px;
+}
+.carousel-1 .object {
+  position: absolute;
+  top: 38px;
+  right: 50%;
+  margin-left: 15px;
+  width: 568px;
+  height: 320px;
+  overflow: hidden;
+}
+.carousel-1 .object.fluid {
+  width: 100%;
+  left: 0;
+  margin: 0;
+}
+.carousel-1 .object iframe {
+  width: 100% !important;
+}
+.carousel-1 .description {
+  position: absolute;
+  top: 55px;
+  left: 50%;
+  margin-left: 50px;
+  width: 514px;
+  height: 290px;
+}
+.carousel-1 .description .title {
+  font-size: 32px;
+  margin: 0 0 15px 0;
+  padding: 8px 20px;
+  line-height: 38px;
+  background: #FFF;
+  color: #616161;
+}
+.carousel-1 .description .subtitle {
+  font-size: 24px;
+  margin: 20px 0;
+  padding: 0;
+  display: block;
+}
+.carousel-1 .description p {
+  font-size: 16px;
+  color: #FFF;
+  margin: 0;
+}
+.carousel-1 .description.fluid-center {
+  width: 100%;
+  top: 50px;
+  left: 0;
+  margin: 0;
+}
+.carousel-1 .description.fluid-center .title {
+  margin-bottom: 5px;
+  display: block;
+  text-align: center;
+  background: none;
+  color: #FFF;
+  font-weight: 500;
+  text-shadow: 1px 1px 3px rgba(150, 150, 150, 0.5);
+}
+.carousel-1 .description.fluid-center .subtitle {
+  font-size: 20px;
+  margin: 0;
+  display: block;
+  text-align: center;
+}
+.carousel-1 .description.fluid-center .features {
+  display: block;
+  margin-top: 40px;
+  text-align: center;
+}
+.carousel-1 .description.fluid-center .features i {
+  width: 110px;
+  height: 110px;
+  background: #FFF;
+  text-align: center;
+  line-height: 110px;
+  font-size: 54px;
+  color: #697e93;
+  font-weight: 700;
+  border-radius: 96px;
+  margin-right: 20px;
+}
+.carousel-4 .carousel-inner {
+  overflow: hidden;
+}
+.carousel-4 .carousel-control i {
+  position: absolute;
+  top: 50%;
+  margin-top: -18px;
+  font-size: 36px;
+  font-weight: 600;
+}
+/* FRACTION SLIDER CUSTOMS */
+.slider-wrapper * {
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  font-family: "Roboto", sans-serif;
+}
+.slider-wrapper {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  max-height: 440px;
+  margin: 0 auto;
+  background: #f2f2f2;
+  z-index: 800;
+}
+.slider {
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
+  background: #f2f2f2;
+}
+.slider-wrapper p {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+.slider-wrapper p {
+  position: absolute;
+  top: -200px;
+  z-index: 8000;
+  padding: 1% 2%;
+  font-size: 24px;
+  line-height: 100%;
+  white-space: nowrap;
+  text-transform: uppercase;
+}
+.slider-wrapper .white {
+  color: #FFF;
+}
+.slider-wrapper .claim {
+  line-height: 100%;
+}
+.slider-wrapper .teaser {
+  font-size: 14px;
+  line-height: 100%;
+}
+.slider-wrapper .small {
+  width: 250px;
+  text-align: center;
+}
+.slider-wrapper .video {
+  width: 540px;
+  height: 360px;
+  font-size: 13px;
+  line-height: 18px;
+  white-space: normal;
+  text-align: left;
+  text-transform: none;
+}
+.slider-wrapper .video iframe {
+  width: 100%;
+}
+.slider-wrapper .text {
+  width: 460px;
+  font-size: 13px;
+  padding: 0 2%;
+  line-height: 18px;
+  white-space: normal;
+  text-align: left;
+  text-transform: none;
+}
+.slider-wrapper .text a {
+  margin-top: 20px;
+}
+.slider-wrapper .slide-light p {
+  color: #FFF;
+}
+.slider-wrapper .slide-light p.claim {
+  width: 50%;
+  white-space: normal;
+  maring-bottom: 20px;
+}
+.slider-wrapper .slide-light p.teaser {
+  font-weight: 300;
+}
+/* SIMPLE SLIDER */
+.simple-slider {
+  height: 500px;
+  background: #f3f3f3;
+}
+/* CALL TO ACTION BOX */
+.cta-wr {
+  padding: 16px 0;
+}
+.cta-wr h1 {
+  margin: 10px 0 !important;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 400;
+}
+/* COLUMNS & SECTIONS */
+section.slice {
+  padding: 30px 0;
+  background: #fff;
+}
+section.slice.relative {
+  position: relative;
+}
+.subsection {
+  margin-top: 30px;
+}
+.container.bordered {
+  border: 1px solid #ddd;
+  padding-top: 15px;
+}
+.w-box:hover .w-box-parent {
+  -webkit-transform: translateY(-40px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.4s;
+  -moz-transition: -moz-transform 0.4s;
+  -o-transition: -o-transform 0.4s;
+  transition: transform 0.4s;
+}
+.w-box .w-box-parent .w-box-button.animated {
+  position: absolute;
+  bottom: 10px;
+  margin-bottom: -40px;
+  -webkit-transition: all 0.3s linear;
+  transition: all 0.3s linear;
+}
+.w-box.w-box-inverse {
+  background: none !important;
+  border: 0;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.w-box.w-box-inverse p {
+  padding: 0;
+}
+.w-box.w-box-inverse h1 {
+  margin: 10px 0 0 0;
+  padding: 10px 0;
+  font-weight: 500;
+  font-size: 20px;
+}
+.w-box.w-box-inverse h2 {
+  margin: 15px 0 0 0;
+  padding: 0;
+  font-weight: 500;
+  font-size: 16px;
+  text-transform: none;
+  border: 0;
+  text-align: center;
+}
+.w-box.w-box-inverse h2 i {
+  font-style: normal;
+}
+.w-box.w-box-inverse ul.meta-list {
+  maring: 0;
+  padding: 0;
+}
+.w-box.w-box-inverse .w-footer {
+  padding: 10px 0;
+}
+.w-box.w-box-inverse .thmb-img {
+  text-align: center;
+}
+.w-box.dark p {
+  color: #f1f1f1;
+}
+.w-box.dark h2 {
+  color: #FFF;
+  text-align: center;
+  margin-bottom: 7px;
+}
+.w-box.dark .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.w-box.dark .thmb-img i {
+  font-size: 64px;
+  color: #FFF;
+}
+.w-box.product {
+  background: #FFF;
+  padding-top: 15px;
+  margin-bottom: 20px;
+}
+.w-box.product .figure {
+  padding: 20px;
+}
+.w-box.product p {
+  text-align: center;
+}
+.w-box.product h2 {
+  border-bottom: 0;
+  text-align: center;
+}
+.w-box.product .thmb-img {
+  text-align: center;
+  padding: 15px 0;
+}
+.w-box.product .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.w-box.product .price {
+  padding: 4px 0;
+}
+.w-box.inverse {
+  background: none;
+  border: 0;
+}
+.w-box.inverse p {
+  padding: 4px 0;
+}
+.w-box.inverse h2 {
+  padding: 10px 0 0 0 !important;
+  border-bottom: 0;
+}
+.w-box.inverse .thmb-img {
+  padding: 15px 0;
+}
+.w-box.inverse .thmb-img i {
+  font-size: 64px;
+  color: #616161;
+}
+.w-box.inverse .social-icons {
+  border: 0 ;
+}
+.w-section {
+  background: #FFF;
+}
+.w-section:before,
+.w-section:after {
+  display: table;
+  content: " ";
+}
+.w-section:after {
+  clear: both;
+}
+.w-section.inverse {
+  background: none !important;
+  -moz-box-shadow: 0 0 0;
+  -webkit-box-shadow: 0 0 0;
+  box-shadow: 0 0 0;
+  border: 0;
+}
+.w-section.inner {
+  margin: 15px 0;
+}
+.w-section iframe {
+  width: 100%;
+}
+.w-section .feature {
+  margin: 15px 0 30px 0;
+  text-align: center;
+  cursor: default;
+}
+.w-section .feature i {
+  font-size: 64px;
+  color: #555;
+  display: block;
+}
+.w-section .feature h4 {
+  margin: 10px 0;
+}
+.w-section .aside-feature h4 {
+  margin: 10px 0;
+}
+.w-section .txt-feature {
+  margin: 15px 0 30px 0;
+  cursor: default;
+}
+.w-section .txt-feature h4 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 10px;
+  font-weight: 500;
+}
+.w-section .txt-fly-over {
+  height: 350px;
+  overflow: hidden;
+  position: absolute;
+  top: -90px;
+  z-index: 1000;
+  padding: 20px;
+}
+.w-section .txt-fly-over h1 {
+  padding: 0;
+  margin: 0;
+  margin-bottom: 10px;
+  font-size: 54px;
+  font-weight: 600;
+  color: #FFF;
+}
+.w-section .txt-fly-over h2 {
+  padding: 0;
+  margin: 0 0 20px 0;
+  font-size: 24px;
+  font-weight: 500;
+}
+.w-section .inline-features i {
+  display: block;
+  margin-bottom: 15px;
+  height: 64px;
+  line-height: 64px;
+  text-align: center;
+  font-size: 40px;
+  background: #555555;
+  color: #fff;
+  border-radius: 3px;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+}
+.w-section .inline-features i:hover {
+  background: #75b918;
+}
+.w-section .contrast-box {
+  padding: 15px;
+  margin-bottom: 20px;
+  border-radius: 3px;
+  border: 1px solid #f3f3f3;
+}
+.w-section .contrast-box i {
+  font-size: 24px;
+  margin-right: 8px;
+}
+.w-section .contrast-box small {
+  display: block;
+  margin-top: 12px;
+  font-style: italic;
+  text-align: right;
+}
+/* WP EXAMPLE */
+.wp-example {
+  margin-bottom: 45px;
+}
+.wp-example pre {
+  border-radius: 0;
+  margin-top: 20px;
+}
+/* SIDEBAR NAV */
+.nav-sidebar-fixed {
+  position: fixed;
+  width: 260px;
+}
+/* SHOP */
+.shop .pagination {
+  margin: 0;
+}
+.shop .product-short-info p {
+  padding: 6px 0;
+  margin: 0;
+}
+.shop .primary-image {
+  border: 1px solid #f3f3f3;
+  padding: 10px;
+}
+.shop .thumbnail-images {
+  margin: 10px 0 25px 0;
+}
+.shop .thumbnail-images a {
+  display: inline-block;
+  width: 100px;
+  height: 100px;
+  padding: 10px;
+  overflow: hidden;
+  margin-right: 5px;
+  border: 1px solid #f3f3f3;
+}
+.shop .thumbnail-images a:last-child {
+  margin: 0;
+}
+.shop .thumbnail-images a img {
+  width: 100%;
+}
+.table-cart {
+  border: 1px solid #ddd;
+}
+.table-cart td {
+  vertical-align: middle;
+}
+.table-cart td:first-child {
+  border-right: 1px solid #ddd;
+}
+.table-cart img {
+  width: 80px;
+}
+.dropdown-cart .table-cart img {
+  width: 50px;
+}
+.table-cart .cart-remove {
+  display: block;
+  text-align: center;
+  color: #e80e1d;
+}
+.table-totals td:nth-child(even) {
+  padding: 5px 15px;
+}
+/* ANIMATION ELEMENTS */
+.animate-wr {
+  animation-duration: 0.5s;
+  -webkit-animation-duration: 0.5s;
+  -moz-animation-duration: 1s;
+  -o-animation-duration: 1s;
+}
+/* HOVER ANIMATIONS 1 */
+.animate-hover-slide .figure {
+  position: relative;
+  overflow: hidden;
+}
+.animate-hover-slide .figure img {
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide .figure .figcaption {
+  height: 100%;
+  padding: 0;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  top: auto;
+  bottom: 0;
+  opacity: 0;
+  -webkit-transform: translateY(100%);
+  -moz-transform: translateY(100%);
+  -ms-transform: translateY(100%);
+  -o-transform: translateY(100%);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide .figure:hover .figcaption {
+  opacity: 0.8;
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s;
+  transition: transform 0.4s, opacity 0.1s;
+}
+.animate-hover-slide .figure .figcaption {
+  text-align: center;
+}
+.animate-hover-slide .figure .figcaption-btn {
+  width: 100%;
+  height: 50%;
+  position: absolute;
+  top: 0px;
+  opacity: 0;
+  padding-left: 20px;
+  text-align: center;
+  -webkit-transform: translateY(-100%);
+  -moz-transform: translateY(-100%);
+  -ms-transform: translateY(-100%);
+  -o-transform: translateY(-100%);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide .figure:hover .figcaption-btn {
+  opacity: 1;
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s;
+  transition: transform 0.4s, opacity 0.1s;
+}
+.animate-hover-slide .figure .figcaption-txt {
+  width: 100%;
+  height: 50%;
+  position: absolute;
+  bottom: 0px;
+  opacity: 0;
+  padding-left: 20px;
+  text-align: center;
+  -webkit-transform: translateY(100%);
+  -moz-transform: translateY(100%);
+  -ms-transform: translateY(100%);
+  -o-transform: translateY(100%);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide .figure:hover .figcaption-txt {
+  opacity: 1;
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s;
+  transition: transform 0.4s, opacity 0.1s;
+}
+.animate-hover-slide .figure .figcaption-txt .title {
+  padding: 0;
+  margin: 30px 0 0 0;
+  color: #fff;
+  font-size: 18px;
+  text-transform: capitalize;
+}
+.animate-hover-slide .figure .figcaption-txt .subtitle {
+  padding: 0;
+  margin: 0;
+  color: #fff;
+  font-size: 12px;
+}
+.animate-hover-slide .figure a {
+  position: relative;
+  top: 94%;
+  margin-top: -11px;
+}
+.animate-hover-slide .figure .figcaption h3 {
+  padding-bottom: 5px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  border-bottom: 1px solid #f2f2f2;
+}
+/* HOVER ANIMATION 2 */
+.animate-hover-slide-2 .figure {
+  position: relative;
+  overflow: hidden;
+}
+.animate-hover-slide-2 .figure img {
+  position: relative;
+  z-index: 2;
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide-2 .figure:hover img {
+  -webkit-transform: scale(0.4);
+  -moz-transform: scale(0.4);
+  -ms-transform: scale(0.4);
+  transform: scale(0.4);
+}
+.animate-hover-slide-2 .figure .figcaption {
+  height: 100%;
+  z-index: 1;
+  position: absolute;
+  top: 0;
+  bottom: auto;
+  background: #f8f8f8;
+  padding: 0 15px;
+  width: 100%;
+  opacity: 1;
+  -webkit-transform: scale(0.4);
+  -moz-transform: scale(0.4);
+  -ms-transform: scale(0.4);
+  transform: scale(0.4);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide-2 .figure:hover .figcaption {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  opacity: 1;
+}
+.animate-hover-slide-2 .figure .figcaption h2 {
+  text-align: center;
+  margin-top: 15px;
+}
+.animate-hover-slide-2 .figure .figcaption .social-icons {
+  width: 100%;
+  position: absolute;
+  bottom: 15px;
+  text-align: center;
+}
+/* HOVER ANIMATION 3 */
+.animate-hover-slide-3 .figure {
+  position: relative;
+  overflow: hidden;
+}
+.animate-hover-slide-3 .figure img {
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide-3 .figure .figcaption {
+  height: 32px;
+  background: #f8f8f8;
+  padding: 0 15px;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  top: auto;
+  bottom: 0;
+  opacity: 0;
+  -webkit-transform: translateY(100%);
+  -moz-transform: translateY(100%);
+  -ms-transform: translateY(100%);
+  -o-transform: translateY(100%);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s 0.3s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s 0.3s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s 0.3s;
+  transition: transform 0.4s, opacity 0.1s 0.3s;
+}
+.animate-hover-slide-3 .figure:hover .figcaption {
+  opacity: 1;
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.4s, opacity 0.1s;
+  -moz-transition: -moz-transform 0.4s, opacity 0.1s;
+  -o-transition: -o-transform 0.4s, opacity 0.1s;
+  transition: transform 0.4s, opacity 0.1s;
+}
+/* PRICING */
+.pricing-plans {
+  margin-bottom: 15px;
+}
+.pricing-plans:before,
+.pricing-plans:after,
+.pricing-table:before,
+.pricing-table:after {
+  display: table;
+  content: " ";
+}
+.pricing-plans:before,
+.pricing-table:before {
+  clear: both;
+}
+.pricing-plans .plan-header {
+  padding-bottom: 15px;
+}
+.pricing-plans .plan-header .popular-tag {
+  padding: 5px 0;
+  text-align: center;
+  text-transform: uppercase;
+}
+.pricing-plans .plan-header small {
+  display: block;
+  text-align: center;
+  font-style: italic;
+}
+.pricing-plans .plan-title {
+  text-align: center;
+  margin: 0;
+  font-size: 28px;
+  font-weight: 500;
+  color: #fff;
+}
+.pricing-plans .price-tag {
+  margin: 0;
+  height: 70px;
+  line-height: 70px;
+  font-size: 58px;
+  font-weight: 500;
+  text-align: center;
+}
+.pricing-plans .price-tag span {
+  font-size: 28px;
+  font-weight: 500;
+}
+.pricing-plans .price-tag span.price-type {
+  font-size: 20px;
+  font-weight: 500;
+}
+.pricing-plans ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.pricing-plans ul li {
+  padding: 10px 20px;
+  border-bottom: 1px solid #f1f1f1;
+  font-size: 13px;
+}
+.pricing-plans ul li:last-child {
+  border-bottom: 0;
+}
+.pricing-plans ul li i {
+  margin-right: 8px;
+}
+.pricing-plans .plan-info {
+  margin: 0;
+  padding: 15px;
+  font-size: 13px;
+  text-align: center;
+  font-style: italic;
+}
+.pricing-plans .plan-select {
+  padding: 15px 0;
+  border-top: 1px solid #f1f1f1;
+}
+.pricing-plans .plan-circle {
+  height: 263px;
+  padding: 0 25px;
+  display: table-cell;
+  vertical-align: middle;
+  border-radius: 200%;
+}
+.pricing-plans .plan-circle .btn {
+  margin-top: 10px;
+}
+.pricing-plans .w-box {
+  margin-top: 20px;
+}
+.pricing-plans .w-box:hover,
+.pricing-table .w-box:hover {
+  -webkit-box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.2);
+}
+.pricing-plans .w-box-inverse:hover,
+.pricing-table .w-box-inverse:hover {
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.pricing-table .w-box {
+  z-index: 1;
+  margin-top: 20px;
+  margin-bottom: 0;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: 0;
+  box-shadow: none;
+}
+.pricing-table .w-box.popular,
+.pricing-plans .w-box.popular {
+  margin-top: 0;
+  -webkit-box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.2);
+}
+.pricing-table .w-box.popular:hover,
+.pricing-plans .w-box.popular:hover {
+  -webkit-box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.3);
+  -moz-box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.3);
+}
+.pricing-table .plan-select {
+  margin-top: 0;
+  border: 0;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #f1f1f1;
+}
+.pricing-table .plan-info {
+  text-align: center;
+  margin-bottom: 15px;
+}
+.pricing-table .table-comparision {
+  background: #FFF;
+  position: relative;
+  top: -2px;
+  z-index: 1000;
+  border-color: #f1f1f1;
+  color: #777;
+}
+.pricing-table .table-comparision th {
+  border-color: #f1f1f1;
+}
+.pricing-table .table-comparision td {
+  text-align: center;
+  border-color: #f1f1f1;
+}
+.pricing-table .table-comparision tr td:first-child {
+  text-align: left;
+}
+/* VERTICAL INFO */
+.vertical-info h4 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+}
+.vertical-info p.delimiter {
+  margin: 10px 0;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #e0dede;
+}
+/* SORT LIST */
+#ulSorList {
+  margin-top: 20px;
+}
+#ulSorList:after {
+  content: '';
+  display: inline-block;
+  width: 100%;
+}
+#ulSorList .mix {
+  display: none;
+  opacity: 0;
+}
+#ulSorList .mix .item {
+  background: #f2f2f2;
+}
+#ulSorList .gap {
+  display: inline-block;
+  width: 200px;
+}
+/* WORK */
+.work {
+  width: 100%;
+  overflow: hidden;
+}
+.work .btn-group {
+  margin-bottom: 10px;
+}
+.work .btn {
+  margin-right: 6px;
+}
+.work .btn-group .btn {
+  margin-right: 0;
+}
+.work .mix {
+  margin-top: 20px;
+}
+.work.work-no-space.g2 .mix {
+  width: 50%;
+  display: inline-block;
+  float: left;
+  margin: 0;
+  padding: 0;
+}
+.work.work-no-space.g3 .mix {
+  width: 33.3%;
+  display: inline-block;
+  float: left;
+  margin: 0;
+  padding: 0;
+}
+.work.work-no-space.g4 .mix {
+  width: 25%;
+  display: inline-block;
+  float: left;
+  margin: 0;
+  padding: 0;
+}
+.work.work-no-space.g5 .mix {
+  width: 20%;
+  display: inline-block;
+  float: left;
+  margin: 0;
+  padding: 0;
+}
+.work.work-no-space .mix .w-box {
+  padding: 0;
+  margin: 0;
+}
+/* MAP CANVAS */
+.map-canvas {
+  height: 300px;
+  margin: 0;
+}
+.map-canvas .info-window-content {
+  min-width: 250px;
+}
+.map-canvas .info-window-content h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.map-canvas .info-window-content h3 {
+  font-size: 14px;
+  font-weight: 500;
+}
+.map-canvas .info-window-content p {
+  margin-top: 20px;
+  text-align: center;
+  font-size: 12px;
+  color: #999;
+  text-shadow: none;
+}
+/* COMMENTS & COMMENT FORM */
+.comments-wr {
+  padding: 0 15px;
+}
+.comments-wr .comment:before,
+.comments-wr .comment:after {
+  display: table;
+  content: " ";
+}
+.comments-wr .comment:after {
+  clear: both;
+}
+.comments-wr .comment {
+  border-bottom: 1px solid #eee;
+  padding: 15px 0;
+}
+.comments-wr .comment:last-child {
+  border-bottom: 0;
+}
+.comments-wr .comment p {
+  padding: 0;
+}
+.comments-wr .comment .comment {
+  margin: 12px 0 0 60px;
+  padding-bottom: 0;
+  border-bottom: 0;
+  border-top: 1px solid #eee;
+}
+.comments-wr .comment img {
+  width: 48px;
+  float: left;
+}
+.comments-wr .comment p {
+  margin-left: 60px;
+  color: #777;
+}
+.comments-wr .comment .comment-author {
+  display: block;
+}
+.comments-wr .comment .comment-author a {
+  font-weight: 600;
+}
+.comment-form {
+  padding: 15px 15px;
+}
+.comment-form h2 {
+  margin-bottom: 15px;
+}
+/* WIDGETS */
+.widget {
+  margin-bottom: 20px;
+}
+.widget-highlight {
+  padding: 15px;
+  background: #fcfcfc;
+  border: 1px solid #f3f3f3;
+}
+/* VIDEO CONTAINER */
+.video-container iframe {
+  margin: 0;
+  border: 0;
+}
+/* MEDIA - PHOTOS */
+.media-photos-list {
+  padding-left: 0;
+  list-style: none;
+  margin-bottom: 0;
+  overflow: hidden;
+}
+.media-photos-list > li {
+  float: left;
+  margin-right: 6px;
+  margin-bottom: 6px;
+}
+.media-photos-list > li img {
+  width: 60px;
+  height: 60px;
+  -webkit-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+}
+.media-photos-list > li img:hover {
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+}
+/* LISTS */
+ul.list-1 {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+ul.list-1 li {
+  margin: 15px 0;
+}
+ul.list-1 time {
+  float: left;
+  display: inline-block;
+  background: #e74c3c;
+  color: #FFF;
+  font-weight: 600;
+  padding: 5px 8px;
+  border-radius: 2px;
+}
+ul.list-1 .txt:before {
+  content: "";
+  position: absolute;
+  margin-left: -10px;
+  margin-top: 6px;
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-right: 10px solid #f3f3f3;
+  border-bottom: 10px solid transparent;
+}
+ul.list-1 .txt {
+  margin-left: 62px;
+  margin-top: 20px;
+  background: #f3f3f3;
+}
+ul.list-1 .txt p {
+  padding: 8px 15px;
+  margin: 0;
+}
+ul.list-2 {
+  -webkit-padding-start: 20px;
+  margin: 15px 0;
+}
+ul.list-2 li {
+  padding-left: 15px;
+  list-style-type: none;
+  background: url(../images/list-style-2.png) no-repeat 0 8px;
+  color: #555;
+}
+ul.list-2 li a {
+  color: #555;
+}
+ul.list-2 li a:hover {
+  color: #83ae34;
+  text-decoration: none;
+}
+ul.list-3 {
+  margin: 0;
+  list-style: none;
+}
+ul.list-3 li {
+  height: 58px;
+  background: #f2f2f2;
+  overflow: hidden;
+  margin-bottom: 13px;
+}
+ul.list-3 li .list-order {
+  width: 58px;
+  height: 58px;
+  position: relative;
+  float: left;
+  text-align: center;
+  line-height: 60px;
+  background: #75b918;
+  font-size: 30px;
+  font-weight: 600;
+  color: #FFF;
+}
+ul.list-3 li .list-order:after {
+  position: absolute;
+  top: 50%;
+  right: 0px;
+  border: 7px solid transparent;
+  height: 1px;
+  width: 0;
+  border-right-color: #f2f2f2;
+  margin-top: -7px;
+  content: '';
+}
+ul.list-3 li .list-content {
+  float: left;
+  height: 58px;
+  margin-left: 8px;
+}
+ul.list-3 li .list-content h5 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 8px 0 4px 0;
+}
+ul.popular {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+ul.popular li {
+  clear: left;
+  border-bottom: 1px dotted #f1f1f1;
+  padding: 10px 0;
+  display: block;
+  width: 100%;
+}
+ul.popular li img {
+  width: 60px;
+}
+ul.popular li p {
+  margin-left: 70px;
+}
+ul.popular li i {
+  color: #a1a1a1;
+  display: block;
+  font-style: normal;
+  font-size: 12px;
+}
+ul.popular li a {
+  font-weight: 400;
+  line-height: 18px;
+}
+ul.popular li a:hover {
+  text-decoration: none;
+  color: #464646;
+}
+ul.popular li span {
+  font-size: 12px;
+}
+ul.featured {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+ul.featured li {
+  clear: left;
+  border-bottom: 1px dotted #f1f1f1;
+  padding: 10px 0 0 0;
+  display: block;
+  width: 100%;
+}
+ul.featured li img {
+  width: 70px;
+}
+ul.featured li p {
+  margin-left: 80px;
+}
+ul.featured li i {
+  color: #a1a1a1;
+  display: block;
+  font-style: normal;
+  font-size: 12px;
+}
+ul.featured li a {
+  font-weight: 500;
+}
+ul.featured li a:hover {
+  text-decoration: none;
+  color: #464646;
+}
+ul.featured li span {
+  font-size: 12px;
+}
+ul.featured li .price {
+  font-size: 16px;
+  font-weight: 500;
+  margin-top: 5px;
+}
+ul.featured li .price.discount {
+  text-decoration: line-through;
+  color: #e74c3c;
+  font-size: 13px;
+  margin-right: 8px;
+}
+ul.recent {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+ul.recent li {
+  border-bottom: 1px dotted #e9e9e9;
+}
+ul.recent li:last-child {
+  border: 0;
+  padding-bottom: 0;
+}
+ul.recent li a {
+  display: block;
+  padding: 10px 0;
+}
+ul.recent li a:hover {
+  border-color: #75b918;
+}
+ul.recent li h6 {
+  margin: 0 0 10px 0;
+}
+ul.recent li h6 a {
+  color: #353535;
+  font-size: 14px;
+  text-transform: none;
+  text-decoration: none;
+  font-weight: 600;
+}
+ul.meta-list {
+  margin: 0;
+  padding: 10px 15px 15px 15px;
+  display: block;
+  list-style: none;
+}
+ul.meta-list li:first-child {
+  padding: 0;
+  border-left: 0;
+}
+ul.meta-list li {
+  display: inline-block;
+  color: #a1a1a1;
+}
+ul.meta-list li a {
+  color: #7a92ac;
+}
+ul.meta-list li a:hover {
+  color: #e06d58;
+  text-decoration: underline;
+}
+ul.bullet {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+ul.bullet li {
+  clear: left;
+  padding: 10px 0;
+  display: block;
+  width: 100%;
+}
+ul.bullet li > figure {
+  margin: 5px 0 0 0;
+  padding: 0;
+  border-radius: 100%;
+  width: 35px;
+  height: 35px;
+  background: #DDD;
+  padding: 8px 0 0;
+  text-align: center;
+  font-size: 17px;
+  color: #fff;
+  font-weight: bold;
+  display: inline-block;
+  float: left;
+}
+ul.bullet li img {
+  width: 60px;
+}
+ul.bullet li h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-left: 15px;
+  display: inline-block;
+}
+ul.bullet li p {
+  margin: 0 0 0 50px;
+  padding: 0;
+}
+ul.bullet li span {
+  margin-left: 6px;
+}
+ul.bullet li a {
+  font-weight: 500;
+}
+ul.bullet li a:hover {
+  text-decoration: none;
+  color: #464646;
+}
+ul.bullet li span {
+  font-size: 12px;
+}
+ul.list-carousel {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+ul.list-carousel li {
+  padding: 6px 0;
+  display: block;
+  width: 100%;
+  font-size: 16px;
+}
+ul.list-carousel li i {
+  font-style: normal;
+  margin-right: 4px;
+}
+ul.list-carousel li a {
+  font-weight: 500;
+}
+ul.list-carousel li a:hover {
+  text-decoration: none;
+  color: #a1a1a1;
+}
+ul.list-carousel li span {
+  font-size: 14px;
+}
+ul.social-icons {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+ul.social-icons li {
+  display: inline-block;
+}
+ul.social-icons li a {
+  display: block;
+  height: 32px;
+  width: 32px;
+  text-align: center;
+  line-height: 32px;
+}
+ul.social-icons li:hover a {
+  color: #fff;
+}
+ul.social-icons li.text {
+  height: 32px;
+  padding-left: 10px;
+  line-height: 32px;
+}
+ul.social-icons li.facebook:hover {
+  background: #43609c;
+  color: #fff;
+}
+ul.social-icons li.twitter:hover {
+  background: #00aced;
+  color: #fff;
+}
+ul.social-icons li.linkedin:hover {
+  background: #517fa4;
+  color: #fff;
+}
+/* TABLES */
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  vertical-align: middle;
+}
+.table.table-no-border > thead > tr > th,
+.table.table-no-border > tbody > tr > th,
+.table.table-no-border > tfoot > tr > th,
+.table.table-no-border > thead > tr > td,
+.table.table-no-border > tbody > tr > td,
+.table.table-no-border > tfoot > tr > td {
+  border-top: 0;
+  padding: 0;
+}
+/* BLOG */
+ul.list-listings.blog-list li {
+  border: 0;
+}
+ul.list-listings.blog-list .listing-header {
+  clear: both;
+  padding: 8px 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+ul.list-listings.blog-list .listing-image {
+  width: 35%;
+  height: 180px;
+  float: left;
+  overflow: hidden;
+}
+ul.list-listings.blog-list .listing-body {
+  width: 65%;
+  height: auto;
+  max-height: auto;
+  padding: 0 15px;
+  float: left;
+  background: #fff;
+}
+ul.list-listings.blog-list .listing-body h3 {
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+ul.list-listings.blog-list .listing-body h4 {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 22px;
+}
+ul.list-listings.blog-list .listing-actions {
+  width: 15%;
+  height: 180px;
+  position: relative;
+  padding-top: 20px;
+  float: left;
+  text-align: center;
+}
+ul.list-listings.blog-list .listing-actions .btn {
+  position: absolute;
+  bottom: 20px;
+  left: 25px;
+}
+ul.list-listings.blog-list .list-item-info {
+  font-size: 12px;
+  font-style: italic;
+}
+.blog-masonry .w-box,
+.blog-grid .w-box,
+.blog-list .w-box {
+  margin-bottom: 25px;
+}
+.w-box.blog-post {
+  border: 0;
+  padding: 0;
+}
+.blog-post h2 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #3b3e43;
+  border: 0;
+  padding: 25px 0px 0px 0px !important;
+}
+.blog-post p {
+  padding: 8px 0px !important;
+  font-size: 14px;
+  color: #777;
+}
+.blog-post blockquote {
+  margin: 8px 0px;
+}
+.blog-post .meta-list {
+  padding-left: 0 !important;
+}
+.blog-post img {
+  width: 100%;
+}
+.side-info {
+  display: block;
+}
+.side-info .date {
+  display: block;
+  text-align: center;
+  margin-top: 5px;
+}
+.side-info .date strong {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 33px;
+  font-weight: normal;
+}
+/* START RATING */
+.star-rating {
+  display: block;
+}
+.star-rating i {
+  display: inline-block !important;
+  color: #f7e90c !important;
+}
+/* REVIEW RATING */
+.review-rating {
+  font-size: 12px;
+}
+/* SKILLS DIAGRAM */
+.skills {
+  clear: both;
+  width: 100%;
+}
+.skills ul,
+.skills li {
+  display: inline-block;
+  list-style: none;
+  margin: 0 6px 0 0;
+  padding: 0;
+}
+.skills li {
+  padding: 0 15px;
+  height: 35px;
+  line-height: 35px;
+  color: #fff;
+  margin-bottom: 1px;
+  font-size: 18px;
+}
+.skills .jq {
+  background: #97BE0D;
+}
+.skills .css {
+  background: #D84F5F;
+}
+.skills .html {
+  background: #88B8E6;
+}
+.skills .php {
+  background: #BEDBE9;
+}
+.skills .sql {
+  background: #EDEBEE;
+}
+/* FORMS */
+.form-control {
+  border-radius: 1px;
+  padding: 8px 12px;
+}
+.form-dark .form-control {
+  margin-bottom: 10px;
+  background: #eee;
+  border: 1px solid #ccc;
+}
+.form-dark label.checkbox {
+  font-size: 12px;
+  font-weight: normal;
+  cursor: pointer;
+}
+.form-dark .form-control:focus {
+  background: #fff;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  border-color: #bbb;
+}
+.form-dark .form-control:-moz-placeholder {
+  color: #999;
+}
+.form-dark .form-control::-moz-placeholder,
+.form-light .form-control[placeholder] {
+  color: #999;
+}
+.form-dark .form-control:-ms-input-placeholder {
+  color: #999;
+}
+.form-dark .form-control::-webkit-input-placeholder {
+  color: #999;
+}
+.form-light .form-control {
+  margin-bottom: 10px;
+  background: #fcfcfc;
+  border: 1px solid #ccc;
+}
+.form-light label.checkbox {
+  font-size: 12px;
+  font-weight: normal;
+  cursor: pointer;
+}
+.form-light .form-control:focus {
+  background: #fff;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  border-color: #bbb;
+}
+.form-light .form-control:-moz-placeholder {
+  color: #999;
+}
+.form-light .form-control::-moz-placeholder,
+.form-light .form-control[placeholder] {
+  color: #999;
+}
+.form-light .form-control:-ms-input-placeholder {
+  color: #999;
+}
+.form-light .form-control::-webkit-input-placeholder {
+  color: #999;
+}
+.sign-in-wr {
+  margin-top: 26px;
+}
+.sign-in-wr .form-icon {
+  display: block;
+  width: 80px;
+  height: 80px;
+  border-radius: 80px;
+  margin: 25px auto;
+  text-align: center;
+  line-height: 80px;
+  font-size: 40px;
+}
+.sign-in-wr .form-header {
+  padding: 15px;
+  border-bottom: 1px solid #f3f3f3;
+}
+.sign-in-wr .form-header h2 {
+  margin: 0;
+  padding: 0 !important;
+  font-size: 18px;
+  font-weight: 500;
+}
+.sign-in-wr .form-body {
+  padding: 15px;
+  background: #fff;
+}
+.sign-in-wr .form-body p {
+  padding-left: 0;
+  margin-bottom: 10px;
+}
+.sign-in-wr .form-footer {
+  padding: 15px 0;
+  border-top: 1px solid #f3f3f3;
+}
+/* SOCIAL ICONS */
+.social-media i {
+  width: 40px;
+  height: 40px;
+  display: inline-block;
+  padding: 10px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  text-align: center;
+  font-size: 18px;
+  background: #ddd;
+  color: #333;
+  border-radius: 2px;
+}
+.social-media .facebook {
+  background: #43609c;
+  color: #FFF;
+}
+.social-media .twitter {
+  background: #62addb;
+  color: #FFF;
+}
+.social-media .google {
+  background: #dd4b39;
+  color: #FFF;
+}
+.social-media i:hover {
+  background: none;
+  color: #a1a1a1;
+}
+/* FORM ERRORS */
+.form-errors {
+  width: 100%;
+  margin-bottom: 20px;
+}
+.form-errors .error {
+  display: block;
+  color: #ce1a33;
+  font-weight: 500;
+}
+.help-inline {
+  font-size: 11px;
+  color: #B8321F;
+  position: relative;
+  top: -8px;
+}
+#info-box {
+  display: none;
+  text-align: center;
+  margin-top: 30px;
+  color: #59b540;
+}
+#info-box h2 {
+  font-size: 16px;
+  font-weight: 600;
+}
+/* MAP CANVAS */
+.map-canvas {
+  margin-top: 30px;
+  height: 300px;
+}
+.map-canvas .info-window-content {
+  min-width: 250px;
+}
+.map-canvas .info-window-content h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.map-canvas .info-window-content h3 {
+  font-size: 14px;
+  font-weight: 500;
+}
+.map-canvas .info-window-content p {
+  font-size: 12px;
+  color: #999;
+  text-shadow: none;
+}
+/* TESTIMONIALS */
+.testimonial-text {
+  width: 70%;
+  margin: 20px auto;
+  font-size: 14px;
+  line-height: 24px;
+}
+.testimonial-author {
+  display: block;
+  text-align: center;
+  color: #a1a1a1;
+  font-style: italic;
+}
+/* CONTACT */
+.contact-info {
+  margin-bottom: 20px;
+}
+.contact-info h5 {
+  margin: 0;
+}
+.carousel-testimonials .testimonial-author-info {
+  padding-top: 28px;
+}
+.carousel-testimonials .testimonial-author-info a {
+  padding-left: 20px;
+}
+/* CLIENTS */
+.client {
+  border: 1px solid #ddd;
+  padding: 0 15px;
+  background: transparent;
+}
+.client img {
+  width: 100%;
+  -webkit-filter: grayscale(100%);
+  -moz-filter: grayscale(100%);
+  filter: grayscale(100%);
+}
+.client img:hover {
+  -webkit-filter: grayscale(0%);
+  -moz-filter: grayscale(0%);
+  filter: grayscale(0%);
+}
+/* FOOTER */
+footer {
+  padding-top: 15px;
+  padding-bottom: 20px;
+  min-height: 30px;
+  background: #232323;
+}
+footer:before,
+footer:after {
+  display: table;
+  content: " ";
+}
+footer:after {
+  clear: both;
+}
+footer .col.reset {
+  margin: 0;
+}
+footer h4 {
+  margin-top: 20px;
+  color: #ccc;
+  margin-bottom: 20px;
+  text-transform: capitalize;
+  font-size: 14px;
+}
+footer .col p {
+  color: #ccc;
+  font-size: 13px;
+  margin-bottom: 10px;
+}
+footer a {
+  color: #ccc;
+  text-decoration: none;
+}
+footer a:hover {
+  text-decoration: none;
+}
+footer .col ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+footer .col ul li {
+  color: #8F8F8F;
+}
+footer .col ul li span {
+  color: #FFF;
+}
+footer .col address {
+  color: #ddd;
+  padding: 8px 0;
+}
+footer .company-info {
+  font-size: 10px;
+  text-align: justify;
+}
+footer .company-info h2 {
+  font-size: 14px;
+  font-weight: 600;
+}
+footer .col.col-social-icons i {
+  width: 40px;
+  height: 40px;
+  display: inline-block;
+  padding: 10px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  text-align: center;
+  font-size: 18px;
+  background: #fff;
+  color: #333;
+  border-radius: 2px;
+}
+footer form {
+  margin-top: 20px;
+}
+footer hr {
+  border-top: 1px solid #444;
+}
+footer .copyright {
+  color: #FFF;
+}
+/* FONT AWESOME */
+.fontawesome-icon-list {
+  margin-top: 22px;
+}
+.fontawesome-icon-list .fa-hover a {
+  display: block;
+  color: #222;
+  line-height: 32px;
+  height: 32px;
+  padding-left: 10px;
+  border-radius: 0;
+}
+.fontawesome-icon-list .fa-hover a .fa {
+  width: 32px;
+  font-size: 14px;
+  display: inline-block;
+  text-align: right;
+  margin-right: 10px;
+}
+.fontawesome-icon-list .fa-hover a:hover {
+  background-color: #1d9d74;
+  color: #fff;
+  text-decoration: none;
+}
+.fontawesome-icon-list .fa-hover a:hover .fa {
+  font-size: 28px;
+  vertical-align: -6px;
+}
+.fontawesome-icon-list .fa-hover a:hover .text-muted {
+  color: #bbe2d5;
+}
+/* RESPONSIVE MEDIA QUERIES */
+@media (min-width: 1200px) {
+  .top-header .aux-text {
+    display: inline-block !important;
+  }
+  .w-section .aside-feature {
+    text-align: left;
+  }
+  .w-section .aside-feature .icon-feature {
+    text-align: left;
+  }
+  .slider {
+    width: 100%;
+  }
+  .w-section .txt-fly-over {
+    height: 350px;
+    top: -90px;
+  }
+  .navbar-default .dropdown-menu,
+  .navbar-wp .dropdown-menu {
+    margin-top: 0px !important;
+  }
+  .navbar-default .dropdown-menu,
+  .navbar-wp .dropdown-menu.dropdown-menu-user {
+    margin-top: 13px !important;
+  }
+  .wrapper.boxed {
+    width: 1230px;
+    margin: auto;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .top-header .aux-text {
+    display: inline-block !important;
+  }
+  .navbar-default .dropdown-menu,
+  .navbar-wp .dropdown-menu {
+    margin-top: 0px !important;
+  }
+  .navbar-default .dropdown-menu,
+  .navbar-wp .dropdown-menu.dropdown-menu-user {
+    margin-top: 13px !important;
+  }
+  .wrapper.boxed {
+    width: 1000px;
+    margin: auto;
+  }
+  .w-section .txt-fly-over {
+    height: 390px;
+    top: -60px;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .top-header .aux-text {
+    display: inline-block !important;
+  }
+  .w-box,
+  .carousel-work .figure {
+    margin-bottom: 15px;
+  }
+  .animate-hover-slide img {
+    width: 100%;
+  }
+  .carousel-1 .object {
+    width: 400px !important;
+  }
+  .slider {
+    width: 100%;
+  }
+  .w-section .txt-fly-over {
+    height: 400px;
+    top: -60px;
+  }
+  .client {
+    margin-bottom: 20px;
+  }
+  .work.work-no-space.g2 .mix {
+    width: 50%;
+  }
+  .work.work-no-space.g3 .mix {
+    width: 50%;
+  }
+  .work.work-no-space.g4 .mix {
+    width: 50%;
+  }
+  .work.work-no-space.g5 .mix {
+    width: 50%;
+  }
+}
+@media (max-width: 767px) {
+  header .navbar-brand {
+    margin: 14px 0;
+  }
+  .navbar-wp .navbar-nav > li > a {
+    color: #4c4c4c;
+    padding: 10px 20px !important;
+    margin-right: 0;
+  }
+  .navbar-wp .navbar-nav > li > a:hover,
+  .navbar-wp .navbar-nav > li > a:focus {
+    color: #FFF;
+    background-color: #e06d58;
+    border-radius: 0 !important;
+  }
+  .navbar-wp .navbar-nav > .active > a,
+  .navbar-wp .navbar-nav > .active > a:hover,
+  .navbar-wp .navbar-nav > .active > a:focus {
+    border-radius: 0 !important;
+  }
+  .navbar-wp .dropdown-menu:after {
+    border: 0 !important;
+    margin-left: 0;
+  }
+  .navbar-wp .dropdown-menu:before {
+    border: 0 !important;
+    margin-left: 0;
+  }
+  .top-header .top-header-menu ul.menu > li ul.sub-menu {
+    display: none !important;
+  }
+  .w-section .aside-feature {
+    text-align: center;
+  }
+  .w-section .aside-feature .icon-feature {
+    text-align: center;
+  }
+  .sort-list-btn .btn {
+    margin-bottom: 10px;
+  }
+  .w-box,
+  .carousel-work .figure {
+    margin-bottom: 15px;
+  }
+  .animate-hover-slide .figure img {
+    width: 100%;
+  }
+  .carousel-1 .carousel-inner {
+    height: 420px;
+  }
+  .carousel-1 .carousel-inner {
+    overflow: hidden;
+  }
+  .carousel-1 .carousel-control i {
+    position: absolute;
+    top: 50%;
+    margin-top: -18px;
+    font-size: 36px;
+    font-weight: 600;
+  }
+  .carousel-1 .item-dark {
+    color: #FFF;
+  }
+  .carousel-1 p {
+    font-size: 16px;
+  }
+  .carousel-1 .object {
+    display: none;
+  }
+  .carousel-1 .object.fluid {
+    width: 100%;
+    left: 0;
+    margin: 0;
+  }
+  .carousel-1 .object iframe {
+    width: 100% !important;
+  }
+  .carousel-1 .description {
+    width: 100% !important;
+    top: 50px;
+    left: 0 !important;
+    margin: 0 !important;
+  }
+  .carousel-1 .description .title {
+    font-size: 32px;
+    margin: 0 0 15px 0;
+    padding: 8px 20px;
+    background: #FFF;
+    color: #9ab2cc;
+    display: block;
+    text-align: center;
+  }
+  .carousel-1 .description .subtitle {
+    font-size: 24px;
+    margin: 20px 0;
+    padding: 0 15px !important;
+    display: block;
+    text-align: center;
+  }
+  .carousel-1 .description p {
+    font-size: 16px;
+    color: #FFF;
+    margin: 0;
+  }
+  .carousel-1 .description.fluid-center .features i {
+    width: 80px;
+    height: 80px;
+    background: #FFF;
+    text-align: center;
+    line-height: 80px;
+    font-size: 34px;
+    color: #697e93;
+    font-weight: 700;
+    border-radius: 80px;
+    margin-right: 20px;
+  }
+  .carousel-1 .list-carousel {
+    padding-left: 30px !important;
+  }
+  .carousel-3 .figure {
+    margin-bottom: 20px;
+  }
+  .slider {
+    height: auto;
+    max-height: 440px;
+    margin: 0;
+  }
+  .cta-wr {
+    text-align: center;
+  }
+  .cta-wr .btn {
+    float: none !important;
+  }
+  .w-section .txt-fly-over {
+    height: 400px;
+    position: static;
+    top: 0;
+  }
+  .client {
+    margin-bottom: 20px;
+  }
+  .work.work-no-space.g2 .mix {
+    width: 100%;
+  }
+  .work.work-no-space.g3 .mix {
+    width: 100%;
+  }
+  .work.work-no-space.g4 .mix {
+    width: 100%;
+  }
+  .work.work-no-space.g5 .mix {
+    width: 100%;
+  }
+}
+@media only screen and (min-width: 1440px) {
+  .slider {
+    width: 100%;
+  }
+}
+@media (max-width: 460px) {
+  .search-wr .search-sign i {
+    margin-left: 0;
+  }
+  .global-search-input {
+    font-size: 16px;
+    padding: 14px 0;
+  }
+}
+
+/*# sourceMappingURL=global-style.css.map */

--- a/themes/boomerang/media/css/global-style.less
+++ b/themes/boomerang/media/css/global-style.less
@@ -9,8 +9,8 @@ License URI: http://wrapbootstrap.com
 */     
 	   
 /* FONTS */
-@import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic);
-@import "http://fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic";
+@import url(//fonts.googleapis.com/css?family=PT+Sans:400,700,400italic);
+@import "//fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic";
  
 /* IMPORTS */ 
 @import url(../assets/bootstrap/css/bootstrap.min.css);     


### PR DESCRIPTION
_*Issue*_: When using `Boomerang` behind an `https` URL, browsers were blocking certain files from loading because of mixed-content errors.

_*Solution*_: remove the `http` scheme, let the browser choose the appropriate scheme based on the scheme of the page loading the CSS.

_Note_: Downloaded Crunch 2 and ran the .less through Crunch, as it appeared that's how the original .css was created.